### PR TITLE
debian: drop custom LTO handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,21 +50,6 @@ if (HAVE_W_GNU_VARIADIC_MACROS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=gnu-zero-variadic-macro-arguments")
 endif ()
 
-# Link time optimization allows leaner, cleaner libraries
-option(WLCS_LINK_TIME_OPTIMIZATION "Enables the linker to optimize binaries." OFF)
-if(WLCS_LINK_TIME_OPTIMIZATION)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-  if(${CMAKE_COMPILER_IS_GNUCXX})
-    # clang defaults to fat LTO, but gcc needs an option to specify
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffat-lto-objects")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffat-lto-objects")
-    set(CMAKE_NM "gcc-nm")
-    set(CMAKE_AR "gcc-ar")
-    set(CMAKE_RANLIB "gcc-ranlib")
-  endif()
-endif()
-
 include(CheckCXXSymbolExists)
 list(APPEND CMAKE_REQUIRED_HEADERS ${GTEST_INCLUDE_DIRECTORIES})
 check_cxx_symbol_exists(INSTANTIATE_TEST_SUITE_P "gtest/gtest.h" HAVE_INSTANTIATE_TEST_SUITE_P)

--- a/debian/rules
+++ b/debian/rules
@@ -8,14 +8,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 COMMON_CONFIGURE_OPTIONS =\
   -DWLCS_BUILD_ASAN=ON \
   -DWLCS_BUILD_UBSAN=ON \
-  -DWLCS_BUILD_TSAN=ON \
-  -DWLCS_LINK_TIME_OPTIMIZATION=ON
-
-# Disable LTO if optimizations are off
-ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)
-	COMMON_CONFIGURE_OPTIONS += -DWLCS_LINK_TIME_OPTIMIZATION=OFF
-	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
-endif
+  -DWLCS_BUILD_TSAN=ON
 
 ifneq ($(filter i386 armhf, $(DEB_HOST_ARCH)),)
   # i386 and armhf do not have tsan

--- a/spread/build/alpine/task.yaml
+++ b/spread/build/alpine/task.yaml
@@ -15,7 +15,6 @@ execute: |
     cd $(mktemp --directory)
     # Alpine doesn't build gcc's libsanitizer
     cmake $SPREAD_PATH \
-        -DWLCS_LINK_TIME_OPTIMIZATION=True \
         -DWLCS_BUILD_ASAN=False \
         -DWLCS_BUILD_TSAN=False \
         -DWLCS_BUILD_UBSAN=False

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -24,8 +24,6 @@ execute: |
 
     cd $SPREAD_PATH
     cd $(mktemp --directory)
-    cmake \
-        -DWLCS_LINK_TIME_OPTIMIZATION=True \
-        $SPREAD_PATH
+    cmake $SPREAD_PATH
     make -j$(nproc)
 

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -23,7 +23,6 @@ execute: |
     cmake \
       -DCMAKE_C_FLAGS="-D_FORTIFY_SOURCE=2" \
       -DCMAKE_CXX_FLAGS="-D_FORTIFY_SOURCE=2" \
-      -DWLCS_LINK_TIME_OPTIMIZATION=True \
       $SPREAD_PATH
     make -j$(nproc)
 


### PR DESCRIPTION
Leave it to the distro instead.