### PR TITLE
spread: add Arch Linux task

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -33,6 +33,7 @@ jobs:
         - lxd:ubuntu-devel:...:gcc
         - lxd:ubuntu-devel:...:clang
         - lxd:alpine-edge:...:gcc
+        - lxd:archlinux-cloud:...:gcc
 
     runs-on: ubuntu-latest
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -17,6 +17,7 @@ backends:
             - alpine-3.19
             - alpine-3.20
             - alpine-edge
+            - archlinux-cloud
 
 suites:
     spread/build/:

--- a/spread/build/archlinux/task.yaml
+++ b/spread/build/archlinux/task.yaml
@@ -2,7 +2,7 @@ summary: Build (on Arch Linux)
 systems: [archlinux-*]
 
 execute: |
-    pacman -S \
+    pacman --noconfirm --sync \
         base-devel \
         cmake \
         boost \

--- a/spread/build/archlinux/task.yaml
+++ b/spread/build/archlinux/task.yaml
@@ -6,6 +6,7 @@ execute: |
         base-devel \
         cmake \
         boost \
+        wayland \
         wayland-protocols \
         gtest
 

--- a/spread/build/archlinux/task.yaml
+++ b/spread/build/archlinux/task.yaml
@@ -1,0 +1,16 @@
+summary: Build (on Arch Linux)
+systems: [archlinux-*]
+
+execute: |
+    pacman -S \
+        base-devel \
+        cmake \
+        boost \
+        wayland-protocols \
+        gtest
+
+    cd $SPREAD_PATH
+    cd $(mktemp --directory)
+    cmake $SPREAD_PATH
+    make -j$(nproc)
+

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -1,5 +1,5 @@
 summary: Build (on Ubuntu)
-systems: [-fedora-*, -alpine-*]
+systems: [ubuntu-*]
 
 execute: |
     # Grab builds of Mir git master


### PR DESCRIPTION
Hello, following the kind request to add spread CI for Arch Linux https://github.com/canonical/mir/issues/3537#issuecomment-2341510597 https://github.com/canonical/mir/issues/3593#issuecomment-2396120297

I started with wlcs because it have less dependencies

I have never used spread, LXC, LXD or any CI/CD before and I have at least an issue with most LXD images

spread.yaml is still unedited 

`spread` compiled yesterday (local Arch pkgbuild)

```
$ spread -v
2024-10-08 18:55:41 Found /home/fabio/Dev-Git/wlcs/spread.yaml.
2024-10-08 18:55:41 Project content is packed for delivery (247.24KB).
2024-10-08 18:55:41 Sequence of jobs produced with -seed=1728406541
2024-10-08 18:55:41 If killed, discard servers with: spread -reuse-pid=527863 -discard
2024-10-08 18:55:41 Allocating lxd:alpine-edge...
2024-10-08 18:55:41 Allocating lxd:ubuntu-devel...
2024-10-08 18:55:41 Allocating lxd:ubuntu-23.10...
2024-10-08 18:55:41 Allocating lxd:fedora-rawhide...
2024-10-08 18:55:41 Allocating lxd:alpine-3.19...
2024-10-08 18:55:41 Allocating lxd:alpine-3.20...
2024-10-08 18:55:41 Allocating lxd:ubuntu-24.04...
2024-10-08 18:55:41 Allocating lxd:fedora-39...
2024-10-08 18:55:41 Allocating lxd:ubuntu-22.04...
2024-10-08 18:55:41 Allocating lxd:fedora-40...
2024-10-08 18:55:41 Using cached LXD image for lxd:ubuntu-23.10: 6f0e5207fc85
2024-10-08 18:55:41 Using cached LXD image for lxd:ubuntu-22.04: 7ff91d595eaf
2024-10-08 18:55:41 Using cached LXD image for lxd:ubuntu-24.04: 788feb0b7c4a
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:alpine-3.19.
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:alpine-edge.
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:fedora-39.
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:alpine-3.20.
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:fedora-rawhide.
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:fedora-40.
2024-10-08 18:55:41 Cannot find cached LXD image for lxd:ubuntu-devel.
2024-10-08 18:55:42 Cannot allocate lxd:alpine-3.19: cannot launch lxd container: 
-----
Creating spread-54-alpine-3-19
Starting spread-54-alpine-3-19            
Error: Failed to run: /usr/bin/lxd forkstart spread-54-alpine-3-19 /var/lib/lxd/containers /var/log/lxd/spread-54-alpine-3-19/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-54-alpine-3-19` for more info
-----
2024-10-08 18:55:42 Cannot allocate lxd:alpine-3.20: cannot launch lxd container: 
-----
Creating spread-57-alpine-3-20
Starting spread-57-alpine-3-20            
Error: Failed to run: /usr/bin/lxd forkstart spread-57-alpine-3-20 /var/lib/lxd/containers /var/log/lxd/spread-57-alpine-3-20/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-57-alpine-3-20` for more info
-----
2024-10-08 18:55:43 Cannot allocate lxd:alpine-edge: cannot launch lxd container: 
-----
Creating spread-55-alpine-edge
Starting spread-55-alpine-edge            
Error: Failed to run: /usr/bin/lxd forkstart spread-55-alpine-edge /var/lib/lxd/containers /var/log/lxd/spread-55-alpine-edge/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-55-alpine-edge` for more info
-----
2024-10-08 18:55:44 Cannot allocate lxd:fedora-39: cannot launch lxd container: 
-----
Creating spread-56-fedora-39
Starting spread-56-fedora-39              
Error: Failed to run: /usr/bin/lxd forkstart spread-56-fedora-39 /var/lib/lxd/containers /var/log/lxd/spread-56-fedora-39/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-56-fedora-39` for more info
-----
2024-10-08 18:55:44 Cannot allocate lxd:fedora-rawhide: cannot launch lxd container: 
-----
Creating spread-58-fedora-rawhide
Starting spread-58-fedora-rawhide         
Error: Failed to run: /usr/bin/lxd forkstart spread-58-fedora-rawhide /var/lib/lxd/containers /var/log/lxd/spread-58-fedora-rawhide/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-58-fedora-rawhide` for more info
-----
2024-10-08 18:55:45 Cannot allocate lxd:fedora-40: cannot launch lxd container: 
-----
Creating spread-59-fedora-40
Starting spread-59-fedora-40              
Error: Failed to run: /usr/bin/lxd forkstart spread-59-fedora-40 /var/lib/lxd/containers /var/log/lxd/spread-59-fedora-40/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-59-fedora-40` for more info
-----
2024-10-08 18:55:45 Cannot allocate lxd:ubuntu-24.04: cannot launch lxd container: 
-----
Creating spread-53-ubuntu-24-04
Starting spread-53-ubuntu-24-04           
Error: Failed to run: /usr/bin/lxd forkstart spread-53-ubuntu-24-04 /var/lib/lxd/containers /var/log/lxd/spread-53-ubuntu-24-04/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-53-ubuntu-24-04` for more info
-----
2024-10-08 18:55:46 Cannot allocate lxd:ubuntu-devel: cannot launch lxd container: 
-----
Creating spread-60-ubuntu-devel
Starting spread-60-ubuntu-devel             
Error: Failed to run: /usr/bin/lxd forkstart spread-60-ubuntu-devel /var/lib/lxd/containers /var/log/lxd/spread-60-ubuntu-devel/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-60-ubuntu-devel` for more info
-----
2024-10-08 18:55:46 Cannot allocate lxd:ubuntu-22.04: cannot launch lxd container: 
-----
Creating spread-52-ubuntu-22-04
Starting spread-52-ubuntu-22-04             
Error: Failed to run: /usr/bin/lxd forkstart spread-52-ubuntu-22-04 /var/lib/lxd/containers /var/log/lxd/spread-52-ubuntu-22-04/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-52-ubuntu-22-04` for more info
-----
2024-10-08 18:55:46 Cannot allocate lxd:ubuntu-23.10: cannot launch lxd container: 
-----
Creating spread-51-ubuntu-23-10
Starting spread-51-ubuntu-23-10           
Error: Failed to run: /usr/bin/lxd forkstart spread-51-ubuntu-23-10 /var/lib/lxd/containers /var/log/lxd/spread-51-ubuntu-23-10/lxc.conf: exit status 1
Try `lxc info --show-log local:spread-51-ubuntu-23-10` for more info
-----
2024-10-08 18:55:46 Successful tasks: 0
2024-10-08 18:55:46 Aborted tasks: 20
error: unsuccessful run
[fabio@archlinux wlcs]$
```

```
 lxc info --show-log local:spread-54-alpine-3-19
Error: Failed to fetch instance "spread-54-alpine-3-19" in project "default": Instance not found
```

```
$ lxc info --show-log local:spread-51-ubuntu-23-10
Error: Failed to fetch instance "spread-51-ubuntu-23-10" in project "default": Instance not found
```


