### PR TITLE
spread: refresh distros

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -22,14 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         spread-task:
-        - lxd:ubuntu-23.10:...:gcc
         - lxd:ubuntu-24.04:...:gcc
         - lxd:ubuntu-24.10:...:gcc
         - lxd:ubuntu-24.10:...:clang
-        - lxd:fedora-39:...:gcc
         - lxd:fedora-40:...:gcc
         - lxd:fedora-rawhide:...:gcc
-        - lxd:alpine-3.19:...:gcc
         - lxd:alpine-3.20:...:gcc
         - lxd:ubuntu-devel:...:gcc
         - lxd:ubuntu-devel:...:clang

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,18 +5,16 @@ kill-timeout: 50m
 backends:
     lxd:
         systems:
-            - ubuntu-22.04
-            - ubuntu-23.10
             - ubuntu-24.04
             - ubuntu-24.10
             - ubuntu-devel:
                 image: ubuntu-daily:devel/amd64
-            - fedora-39
             - fedora-40
+            - fedora-41
             - fedora-rawhide:
                 image: images:fedora/40
-            - alpine-3.19
             - alpine-3.20
+            - alpine-3.21
             - alpine-edge
             - archlinux-cloud
 


### PR DESCRIPTION
Can't turn fedora-41 and alpine-3.21 on just yet, they're missing LXD images.