### PR TITLE
FrameSubmission: Expand test for Firefox frame storm.

### DIFF
--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -16,10 +16,8 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#include "helpers.h"
 #include "in_process_server.h"
 
-#include <functional>
 #include <gmock/gmock.h>
 
 using namespace testing;

--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -153,7 +153,7 @@ TEST_F(FrameSubmission, when_client_endlessly_requests_frame_then_callbacks_are_
  */
 TEST_F(FrameSubmission, frame_requests_without_buffer_are_called_back_eventually)
 {
-    std::array<bool, 5> called = {0};
+    std::array<bool, 5> called{};
 
     wlcs::Client client{the_server()};
     auto surface = client.create_visible_surface(640, 480);


### PR DESCRIPTION
The existing test checks that we don't generate a frame storm, but does *not* check that we actually send a frame callback, so simply dropping any of these requests on the floor passes.

Add an extra test checking that we actually send these frame callbacks.