### PR TITLE
Add helpers for "how long should a timeout be"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,14 @@ set(
   ${WLCS_TESTS}
 )
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+  set(TEST_TIMEOUT_MULTIPLIER "2")
+else()
+  set(TEST_TIMEOUT_MULTIPLIER "1")
+endif()
+
+set_property(SOURCE src/helpers.cpp APPEND PROPERTY COMPILE_DEFINITIONS -DTEST_TIMEOUT_MULTIPLIER=${TEST_TIMEOUT_MULTIPLIER})
+
 # g++ 9.4 (on 20.04) hates the MOCK_METHOD macro
 if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
   # Neither gnu-zero-variadic-macro-arguments nor variadic-macro help,

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -19,6 +19,7 @@
 #ifndef WLCS_HELPERS_H_
 #define WLCS_HELPERS_H_
 
+#include <chrono>
 #include <cstddef>
 #include <memory>
 
@@ -38,6 +39,24 @@ char const** get_argv();
 void set_entry_point(std::shared_ptr<WlcsServerIntegration const> const& entry_point);
 
 std::shared_ptr<WlcsServerIntegration const> get_test_hooks();
+
+/**
+ * A short duration.
+ *
+ * Use this when you need to wait for something to happen in the success case
+ * (that you have no way of monitoring otherwise), like verifying that an action
+ * did *not* change a window property.
+ */
+auto a_short_time() -> std::chrono::seconds;
+
+/**
+ * A long duration.
+ *
+ * Use this where you're waiting for something to happen and need a timeout
+ * to determine when to give up waiting, like committing a buffer to a surface
+ * and waiting for the previous buffer to be released.
+ */
+auto a_long_time() -> std::chrono::seconds;
 }
 }
 

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <chrono>
 
+#include "helpers.h"
 #include "shared_library.h"
 #include "wl_handle.h"
 
@@ -276,7 +277,7 @@ public:
 
     void dispatch_until(
         std::function<bool()> const& predicate,
-        std::chrono::seconds timeout = std::chrono::seconds{10});
+        std::chrono::seconds timeout = helpers::a_long_time());
 
     template<typename WlType>
     auto bind_if_supported(VersionSpecifier const& version) -> WlHandle<WlType>

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -136,3 +136,13 @@ std::shared_ptr<WlcsServerIntegration const> wlcs::helpers::get_test_hooks()
 {
     return ::entry_point;
 }
+
+auto wlcs::helpers::a_short_time() -> std::chrono::seconds
+{
+    return std::chrono::seconds{1 * TEST_TIMEOUT_MULTIPLIER};
+}
+
+auto wlcs::helpers::a_long_time() -> std::chrono::seconds
+{
+    return std::chrono::seconds{10 * TEST_TIMEOUT_MULTIPLIER};
+}


### PR DESCRIPTION
And then use this to make those timeouts *architecture specific*,
since RISCV is so slow that it often hits existing timeouts.