### PR TITLE
Replace deprecatred MOCK_METHODn macros with MOCK_METHOD

### DIFF
--- a/include/mock_text_input_v2.h
+++ b/include/mock_text_input_v2.h
@@ -39,8 +39,8 @@ public:
         zwp_text_input_v2_add_listener(proxy, &listener, this);
     }
 
-    MOCK_METHOD2(on_enter, void(uint32_t, wl_surface*));
-    MOCK_METHOD2(on_leave, void(uint32_t, wl_surface*));
+    MOCK_METHOD(void, on_enter, (uint32_t, wl_surface*));
+    MOCK_METHOD(void, on_leave, (uint32_t, wl_surface*));
     void enter(uint32_t in_serial, wl_surface* surface)
     {
         serial = in_serial;
@@ -51,19 +51,19 @@ public:
         serial = in_serial;
         on_leave(in_serial, surface);
     }
-    MOCK_METHOD5(input_panel_state, void(uint32_t, int32_t, int32_t, int32_t, int32_t));
-    MOCK_METHOD2(preedit_string, void(std::string const&, std::string const&));
-    MOCK_METHOD3(predit_styling, void(uint32_t, uint32_t, uint32_t));
-    MOCK_METHOD1(preedit_cursor, void(int32_t));
-    MOCK_METHOD1(commit_string, void(std::string const&));
-    MOCK_METHOD2(cursor_position, void(int32_t, int32_t));
-    MOCK_METHOD2(delete_surrounding_text, void(uint32_t, uint32_t));
-    MOCK_METHOD1(modifiers_map, void(wl_array*));
-    MOCK_METHOD4(keysym, void(uint32_t, uint32_t, uint32_t, uint32_t));
-    MOCK_METHOD1(language, void(std::string const&));
-    MOCK_METHOD1(text_direction, void(uint32_t));
-    MOCK_METHOD2(configure_surrounding_text, void(int32_t, int32_t));
-    MOCK_METHOD2(on_input_method_changed, void(uint32_t, uint32_t));
+    MOCK_METHOD(void, input_panel_state, (uint32_t, int32_t, int32_t, int32_t, int32_t));
+    MOCK_METHOD(void, preedit_string, (std::string const&, std::string const&));
+    MOCK_METHOD(void, predit_styling, (uint32_t, uint32_t, uint32_t));
+    MOCK_METHOD(void, preedit_cursor, (int32_t));
+    MOCK_METHOD(void, commit_string, (std::string const&));
+    MOCK_METHOD(void, cursor_position, (int32_t, int32_t));
+    MOCK_METHOD(void, delete_surrounding_text, (uint32_t, uint32_t));
+    MOCK_METHOD(void, modifiers_map, (wl_array*));
+    MOCK_METHOD(void, keysym, (uint32_t, uint32_t, uint32_t, uint32_t));
+    MOCK_METHOD(void, language, (std::string const&));
+    MOCK_METHOD(void, text_direction, (uint32_t));
+    MOCK_METHOD(void, configure_surrounding_text, (int32_t, int32_t));
+    MOCK_METHOD(void, on_input_method_changed, (uint32_t, uint32_t));
     void input_method_changed(uint32_t in_serial, uint32_t reason)
     {
         serial = in_serial;

--- a/include/mock_text_input_v3.h
+++ b/include/mock_text_input_v3.h
@@ -44,12 +44,12 @@ public:
         zwp_text_input_v3_add_listener(proxy, &listener, this);
     }
 
-    MOCK_METHOD1(enter, void(wl_surface *));
-    MOCK_METHOD1(leave, void(wl_surface *));
-    MOCK_METHOD3(preedit_string, void(std::string const&, int32_t, int32_t));
-    MOCK_METHOD1(commit_string, void(std::string const&));
-    MOCK_METHOD2(delete_surrounding_text, void(int32_t, int32_t));
-    MOCK_METHOD1(done, void(int32_t));
+    MOCK_METHOD(void, enter, (wl_surface *));
+    MOCK_METHOD(void, leave, (wl_surface *));
+    MOCK_METHOD(void, preedit_string, (std::string const&, int32_t, int32_t));
+    MOCK_METHOD(void, commit_string, (std::string const&));
+    MOCK_METHOD(void, delete_surrounding_text, (int32_t, int32_t));
+    MOCK_METHOD(void, done, (int32_t));
 
     static zwp_text_input_v3_listener constexpr listener {
         method_event_impl<&MockTextInputV3::enter>,

--- a/include/pointer_constraints_unstable_v1.h
+++ b/include/pointer_constraints_unstable_v1.h
@@ -61,8 +61,8 @@ public:
 
     ~ZwpConfinedPointerV1();
 
-    MOCK_METHOD0(confined, void());
-    MOCK_METHOD0(unconfined, void());
+    MOCK_METHOD(void, confined, ());
+    MOCK_METHOD(void, unconfined, ());
 
     operator zwp_confined_pointer_v1*() const;
 
@@ -86,8 +86,8 @@ public:
 
     ~ZwpLockedPointerV1();
 
-    MOCK_METHOD0(locked, void());
-    MOCK_METHOD0(unlocked, void());
+    MOCK_METHOD(void, locked, ());
+    MOCK_METHOD(void, unlocked, ());
 
     operator zwp_locked_pointer_v1*() const;
 

--- a/include/relative_pointer_unstable_v1.h
+++ b/include/relative_pointer_unstable_v1.h
@@ -55,10 +55,10 @@ public:
     ZwpRelativePointerV1(ZwpRelativePointerManagerV1& manager, wl_pointer* pointer);
     ~ZwpRelativePointerV1();
 
-    MOCK_METHOD6(relative_motion,
-                 void(uint32_t utime_hi, uint32_t utime_lo,
-                     wl_fixed_t dx, wl_fixed_t dy,
-                     wl_fixed_t dx_unaccel, wl_fixed_t dy_unaccel));
+    MOCK_METHOD(void, relative_motion,
+                 (uint32_t utime_hi, uint32_t utime_lo,
+                 wl_fixed_t dx, wl_fixed_t dy,
+                 wl_fixed_t dx_unaccel, wl_fixed_t dy_unaccel));
 
     operator zwp_relative_pointer_v1*() const;
 

--- a/tests/copy_cut_paste.cpp
+++ b/tests/copy_cut_paste.cpp
@@ -61,14 +61,14 @@ struct MockDataDeviceListener : DataDeviceListener
 {
     using DataDeviceListener::DataDeviceListener;
 
-    MOCK_METHOD2(data_offer, void(struct wl_data_device* wl_data_device, struct wl_data_offer* id));
+    MOCK_METHOD(void, data_offer, (struct wl_data_device* wl_data_device, struct wl_data_offer* id));
 };
 
 struct MockDataOfferListener : DataOfferListener
 {
     using DataOfferListener::DataOfferListener;
 
-    MOCK_METHOD2(offer, void(struct wl_data_offer* data_offer, char const* MimeType));
+    MOCK_METHOD(void, offer, (struct wl_data_offer* data_offer, char const* MimeType));
 };
 
 struct CCnPSink : Client

--- a/tests/gtk_primary_selection.cpp
+++ b/tests/gtk_primary_selection.cpp
@@ -80,24 +80,24 @@ struct MockGtkPrimarySelectionDeviceListener : GtkPrimarySelectionDeviceListener
 {
     using GtkPrimarySelectionDeviceListener::GtkPrimarySelectionDeviceListener;
 
-    MOCK_METHOD2(data_offer, void(gtk_primary_selection_device* device, gtk_primary_selection_offer* offer));
-    MOCK_METHOD2(selection, void(gtk_primary_selection_device* device, gtk_primary_selection_offer* offer));
+    MOCK_METHOD(void, data_offer, (gtk_primary_selection_device* device, gtk_primary_selection_offer* offer));
+    MOCK_METHOD(void, selection, (gtk_primary_selection_device* device, gtk_primary_selection_offer* offer));
 };
 
 struct MockGtkPrimarySelectionOfferListener : GtkPrimarySelectionOfferListener
 {
     using GtkPrimarySelectionOfferListener::GtkPrimarySelectionOfferListener;
 
-    MOCK_METHOD2(offer, void(gtk_primary_selection_offer* offer, const char* mime_type));
+    MOCK_METHOD(void, offer, (gtk_primary_selection_offer* offer, const char* mime_type));
 };
 
 struct MockGtkPrimarySelectionSourceListener : GtkPrimarySelectionSourceListener
 {
     using GtkPrimarySelectionSourceListener::GtkPrimarySelectionSourceListener;
 
-    MOCK_METHOD3(send, void(gtk_primary_selection_source* source, const char* mime_type, int32_t fd));
+    MOCK_METHOD(void, send, (gtk_primary_selection_source* source, const char* mime_type, int32_t fd));
 
-    MOCK_METHOD1(cancelled, void(gtk_primary_selection_source*));
+    MOCK_METHOD(void, cancelled, (gtk_primary_selection_source*));
 };
 
 struct StubGtkPrimarySelectionDeviceListener : GtkPrimarySelectionDeviceListener

--- a/tests/primary_selection.cpp
+++ b/tests/primary_selection.cpp
@@ -81,24 +81,24 @@ struct MockPrimarySelectionDeviceListener : PrimarySelectionDeviceListener
 {
     using PrimarySelectionDeviceListener::PrimarySelectionDeviceListener;
 
-    MOCK_METHOD2(data_offer, void(zwp_primary_selection_device_v1* device, zwp_primary_selection_offer_v1* offer));
-    MOCK_METHOD2(selection, void(zwp_primary_selection_device_v1* device, zwp_primary_selection_offer_v1* offer));
+    MOCK_METHOD(void, data_offer, (zwp_primary_selection_device_v1* device, zwp_primary_selection_offer_v1* offer));
+    MOCK_METHOD(void, selection, (zwp_primary_selection_device_v1* device, zwp_primary_selection_offer_v1* offer));
 };
 
 struct MockPrimarySelectionOfferListener : PrimarySelectionOfferListener
 {
     using PrimarySelectionOfferListener::PrimarySelectionOfferListener;
 
-    MOCK_METHOD2(offer, void(zwp_primary_selection_offer_v1* offer, const char* mime_type));
+    MOCK_METHOD(void, offer, (zwp_primary_selection_offer_v1* offer, const char* mime_type));
 };
 
 struct MockPrimarySelectionSourceListener : PrimarySelectionSourceListener
 {
     using PrimarySelectionSourceListener::PrimarySelectionSourceListener;
 
-    MOCK_METHOD3(send, void(zwp_primary_selection_source_v1* source, const char* mime_type, int32_t fd));
+    MOCK_METHOD(void, send, (zwp_primary_selection_source_v1* source, const char* mime_type, int32_t fd));
 
-    MOCK_METHOD1(cancelled, void(zwp_primary_selection_source_v1*));
+    MOCK_METHOD(void, cancelled, (zwp_primary_selection_source_v1*));
 };
 
 struct StubPrimarySelectionDeviceListener : PrimarySelectionDeviceListener

--- a/tests/text_input_v2_with_input_method_v1.cpp
+++ b/tests/text_input_v2_with_input_method_v1.cpp
@@ -54,14 +54,14 @@ struct TextInputV2WithInputMethodV1Test : wlcs::StartedInProcessServer
         app_client.roundtrip();
     }
 
-    MOCK_METHOD1(on_activate, void(zwp_input_method_context_v1*));
+    MOCK_METHOD(void, on_activate, (zwp_input_method_context_v1*));
     void activate(zwp_input_method_context_v1* context)
     {
         input_method_context = std::make_unique<NiceMock<wlcs::MockInputMethodContextV1>>(context);
         on_activate(context);
     }
 
-    MOCK_METHOD1(deactivate, void(zwp_input_method_context_v1*));
+    MOCK_METHOD(void, deactivate, (zwp_input_method_context_v1*));
 
     static zwp_input_method_v1_listener constexpr listener {
         wlcs::method_event_impl<&TextInputV2WithInputMethodV1Test::activate>,

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -236,7 +236,7 @@ public:
     virtual auto create_child_popup() -> std::unique_ptr<XdgPopupManagerBase> = 0;
     virtual void dispatch_until_popup_configure() = 0;
 
-    MOCK_METHOD0(popup_done, void());
+    MOCK_METHOD(void, popup_done, ());
 
     wlcs::Server& the_server;
 


### PR DESCRIPTION
Makes it clearer to new test writers what API to use.