### PR TITLE
bad_buffer,toplevel: undisable tests

### DIFF
--- a/tests/test_bad_buffer.cpp
+++ b/tests/test_bad_buffer.cpp
@@ -147,7 +147,7 @@ TEST_F(BadBufferTest, client_lies_about_buffer_size)
 
 using SecondBadBufferTest = wlcs::InProcessServer;
 
-TEST_F(SecondBadBufferTest, DISABLED_test_truncated_shm_file)
+TEST_F(SecondBadBufferTest, test_truncated_shm_file)
 {
 	using namespace testing;
 

--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -597,7 +597,7 @@ TEST_F(XdgToplevelStableConfigurationTest, window_can_unfullscreen_itself)
     EXPECT_THAT(state.activated, Eq(true));
 }
 
-TEST_F(XdgToplevelStableConfigurationTest, DISABLED_window_stays_maximized_after_fullscreen)
+TEST_F(XdgToplevelStableConfigurationTest, window_stays_maximized_after_fullscreen)
 {
     wlcs::Client client{the_server()};
     ConfigurationWindow window{client};
@@ -624,7 +624,7 @@ TEST_F(XdgToplevelStableConfigurationTest, DISABLED_window_stays_maximized_after
     EXPECT_THAT(state.activated, Eq(true));
 }
 
-TEST_F(XdgToplevelStableConfigurationTest, DISABLED_window_can_maximize_itself_while_fullscreen)
+TEST_F(XdgToplevelStableConfigurationTest, window_can_maximize_itself_while_fullscreen)
 {
     wlcs::Client client{the_server()};
     ConfigurationWindow window{client};


### PR DESCRIPTION
Two actually pass, another is excluded on Mir