### PR TITLE
Enable generation of compile_commands.json for use by clangd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ include(GNUInstallDirs)
 find_package(PkgConfig)
 #include (Doxygen.cmake)
 
+# Enable generation of compile_commands.json, for use by the clangd LSP
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Generating the compile_commands.json file adds minimal overhead, and improves IDE integration via the clangd language server.

Enabling it by default means individual developers don't need to configure this themselves to benefit.