### PR TITLE
Relax ordering expecations in bad buffer test

### DIFF
--- a/tests/test_bad_buffer.cpp
+++ b/tests/test_bad_buffer.cpp
@@ -73,8 +73,6 @@ TEST_F(BadBufferTest, test_truncated_shm_file)
 
     wlcs::Client client{the_server()};
 
-    bool buffer_consumed{false};
-
     auto surface = client.create_visible_surface(200, 200);
 
     wl_buffer* bad_buffer = create_bad_shm_buffer(client, 200, 200);
@@ -82,13 +80,12 @@ TEST_F(BadBufferTest, test_truncated_shm_file)
     wl_surface_attach(surface, bad_buffer, 0, 0);
     wl_surface_damage(surface, 0, 0, 200, 200);
 
-    surface.add_frame_callback([&buffer_consumed](int) { buffer_consumed = true; });
-
     wl_surface_commit(surface);
 
     try
     {
-        client.dispatch_until([&buffer_consumed]() { return buffer_consumed; });
+        // We dispatch until we receive the protocol error, or hit the timeout.
+        client.dispatch_until([]() { return false; });
     }
     catch (wlcs::ProtocolError const& err)
     {
@@ -153,8 +150,6 @@ TEST_F(SecondBadBufferTest, test_truncated_shm_file)
 
     wlcs::Client client{the_server()};
 
-    bool buffer_consumed{false};
-
     auto surface = client.create_visible_surface(200, 200);
 
     wl_buffer* bad_buffer = create_bad_shm_buffer(client, 200, 200);
@@ -162,13 +157,12 @@ TEST_F(SecondBadBufferTest, test_truncated_shm_file)
     wl_surface_attach(surface, bad_buffer, 0, 0);
     wl_surface_damage(surface, 0, 0, 200, 200);
 
-    surface.add_frame_callback([&buffer_consumed](int) { buffer_consumed = true; });
-
     wl_surface_commit(surface);
 
     try
     {
-        client.dispatch_until([&buffer_consumed]() { return buffer_consumed; });
+        // We dispatch until we receive the protocol error, or hit the timeout.
+        client.dispatch_until([]() { return false; });
     }
     catch (wlcs::ProtocolError const& err)
     {


### PR DESCRIPTION
We expect submitting a bad SHM buffer to result in a protocol exception, but
it's not required to do so before firing the frame callback. Indeed, there
*are* no ordering expectations on when to expect the protocol error.

So, instead of waiting for the frame callback, just dispatch until we
*do* get a protocol exception (or timeout).