### PR TITLE
wlcs.pc: Add a “test revisions” variable section

### DIFF
--- a/wlcs.pc.in
+++ b/wlcs.pc.in
@@ -17,4 +17,4 @@ Cflags: -I${includedir}
 # behaviours the revision of the test is incremented here, to allow downstreams
 # to detect when the WLCS test will incorrectly fail.
 
-BadBuffer_test_truncated_shm_file_revision=1
+BadBufferTest_test_truncated_shm_file_revision=1


### PR DESCRIPTION
This can be used by consumers of wlcs to detect when a test is fixed to more correctly validate protocol behaviour, and so when it might be expected to fail on correct implementations.

Set the revision of `BadBufferTest.test_truncated_shm_file` to 1, as
this is the first test we have to use this feature on.