### PR TITLE
hack: Ensure surfaces aren't entirely occluded by cursor

### DIFF
--- a/tests/ext_foreign_toplevel_list_v1.cpp
+++ b/tests/ext_foreign_toplevel_list_v1.cpp
@@ -34,7 +34,7 @@ WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_handle_v1)
 
 namespace
 {
-int const w = 10, h = 15;
+int const w = 100, h = 150;
 
 class ForeignToplevelHandle
 {

--- a/tests/wlr_foreign_toplevel_management_v1.cpp
+++ b/tests/wlr_foreign_toplevel_management_v1.cpp
@@ -36,7 +36,7 @@ WLCS_CREATE_INTERFACE_DESCRIPTOR(zwlr_foreign_toplevel_handle_v1)
 
 namespace
 {
-int const w = 10, h = 15;
+int const w = 100, h = 150;
 
 class ForeignToplevelHandle
 {

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -202,6 +202,14 @@ public:
 
     void map_popup(PositionerParams const& params)
     {
+        // TODO: This hack is to ensure that the cursor is not positioned at (0,0)
+        // If the cursor *is* at (0,0), then the cursor image may entirely occlude
+        // a surface placed almost off the display, which results in frame events
+        // never being generated and the final `dispatch_until` timing out.
+
+        auto pointer = the_server.create_pointer();
+        pointer.move_to(300, 300);
+
         popup_surface.emplace(*client);
         setup_popup(params);
         wl_surface_commit(popup_surface.value());


### PR DESCRIPTION
Our tests tend to wait for a `surface.frame` event to ensure that a surface has been mapped.

Unfortunately, this is not always accurate. Particularly: if a surface is entirely occluded by another (or by the cursor) then a new frame is not required and the compositor will not send a `surface.frame` event even once the surface *is* mapped.

Because plumbing surface introspection through the WLCS hooks is going to be a longer-term project, just ensure that the surfaces that hit this problem are definitely not occluded by the cursor.