### PR TITLE
Add test to make sure that layer shell surfaces are not remapped with the wrong position when hidden by fullscreen surfaces.

### DIFF
--- a/tests/wlr_layer_shell_v1.cpp
+++ b/tests/wlr_layer_shell_v1.cpp
@@ -1300,11 +1300,9 @@ TEST_F(LayerSurfaceTest, layer_surface_remains_configured_when_occluded_by_fulls
         << "Fullscreen window should still be under cursor at top";
 
     // Check if layer surface incorrectly appeared in the middle (the bug)
-    Point middle_of_screen{
-        output.top_left.x.as_int() + output.size.width.as_int() / 2,
-        output.top_left.y.as_int() + output.size.height.as_int() / 2
-    };
-    pointer.move_to(middle_of_screen.x.as_int(), middle_of_screen.y.as_int());
+    auto middle_x = output.top_left.x.as_int() + output.size.width.as_int() / 2;
+    auto middle_y = output.top_left.y.as_int() + output.size.height.as_int() / 2;
+    pointer.move_to(middle_x, middle_y);
     client.roundtrip();
 
     if (client.window_under_cursor() == (wl_surface*)surface)


### PR DESCRIPTION
Discovered while working on https://github.com/canonical/mir/pull/4664

tl;dr of what's wrong:
>     When we enter fullscreen, we set the window's state to hidden, which works fine.
> 
>     The bug occurs when the bar submits a frame. This piece of code here sees that the surface is not mapped, but it submitted a buffer, so it should be mapped. It then sets its state to restored: https://github.com/canonical/mir/blob/7e7e41f259a0cba81e870467d488d1dda37913a2/src/server/frontend_xwayland/xwayland_surface_role.cpp#L136-L141
> 
>     Execution reaches this piece of code, where it sees the state as restored and sees that the restore rect does not overlap the application zone, because layer shell zones may have an exclusion zone, which shrinks the application zone: https://github.com/canonical/mir/blob/7e7e41f259a0cba81e870467d488d1dda37913a2/src/miral/basic_window_manager.cpp#L1445-L1452
> 
>     Then clamp_top actually does not clamp, it centers the surface vertically: https://github.com/canonical/mir/blob/7e7e41f259a0cba81e870467d488d1dda37913a2/src/miral/basic_window_manager.cpp#L48-L51
> 
>     Which leads to the bars (see next thread) appearing in the middle of the screen.