### PR TITLE
Add some basic tests for toplevel image capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ set(
   include/input_method.h
   include/xdg_decoration_unstable_v1.h
   include/linux_dmabuf_v1.h
+  include/ext_foreign_toplevel_list_v1.h
 
   src/data_device.cpp
   src/gtk_primary_selection.cpp
@@ -256,6 +257,7 @@ set(
   src/input_method.cpp
   src/xdg_decoration_unstable_v1.cpp
   src/linux_dmabuf_v1.cpp
+  src/ext_foreign_toplevel_list_v1.cpp
 
   ${PROTOCOL_SOURCES}
   ${WLCS_TESTS}

--- a/include/ext_foreign_toplevel_list_v1.h
+++ b/include/ext_foreign_toplevel_list_v1.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WLCS_EXT_FOREIGN_TOPLEVEL_LIST_V1_H
+#define WLCS_EXT_FOREIGN_TOPLEVEL_LIST_V1_H
+
+#include "generated/ext-foreign-toplevel-list-v1-client.h"
+#include "wl_interface_descriptor.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace wlcs
+{
+WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_list_v1)
+WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_handle_v1)
+
+class Client;
+
+class ExtForeignToplevelHandleV1
+{
+public:
+    ExtForeignToplevelHandleV1(ext_foreign_toplevel_handle_v1* handle);
+    ~ExtForeignToplevelHandleV1();
+
+    auto is_dirty() const -> bool;
+    auto closed() const -> bool;
+    auto title() const -> std::optional<std::string>;
+    auto app_id() const -> std::optional<std::string>;
+    auto identifier() const -> std::optional<std::string>;
+
+    operator ext_foreign_toplevel_handle_v1*() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> const impl;
+};
+
+class ExtForeignToplevelListV1
+{
+public:
+    ExtForeignToplevelListV1(wlcs::Client& client);
+    ~ExtForeignToplevelListV1();
+
+    auto toplevels() const -> std::vector<std::unique_ptr<ExtForeignToplevelHandleV1>> const&;
+    auto toplevel() const -> ExtForeignToplevelHandleV1 const&;
+    auto toplevel(std::string const& app_id) const -> ExtForeignToplevelHandleV1 const&;
+    void remove(ExtForeignToplevelHandleV1 const& toplevel);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> const impl;
+};
+
+}
+
+#endif /* WLCS_EXT_FOREIGN_TOPLEVEL_LIST_V1_H */

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -202,6 +202,7 @@ private:
 };
 
 class Client;
+class ShmBuffer;
 
 class Surface
 {
@@ -214,8 +215,10 @@ public:
     operator ::wl_surface*() const;
     auto wl_surface() const -> ::wl_surface* { return *this; };
 
+    void attach_buffer(ShmBuffer const& buffer);
     void attach_buffer(int width, int height);
     void add_frame_callback(std::function<void(int)> const& on_frame);
+    void attach_visible_buffer(ShmBuffer const& buffer);
     void attach_visible_buffer(int width, int height);
     void run_on_destruction(std::function<void()> callback);
 

--- a/src/ext_foreign_toplevel_list_v1.cpp
+++ b/src/ext_foreign_toplevel_list_v1.cpp
@@ -192,7 +192,7 @@ auto wlcs::ExtForeignToplevelListV1::toplevel(std::string const& app_id) const -
         }
     }
     if (!match)
-        BOOST_THROW_EXCEPTION(std::runtime_error("No toplevels have the app ID " + app_id));
+        BOOST_THROW_EXCEPTION(std::out_of_range("No toplevels have the app ID " + app_id));
     if (match.value()->is_dirty())
         BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
     return *match.value();

--- a/src/ext_foreign_toplevel_list_v1.cpp
+++ b/src/ext_foreign_toplevel_list_v1.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ext_foreign_toplevel_list_v1.h"
+#include "in_process_server.h"
+#include "version_specifier.h"
+#include "wl_handle.h"
+
+#include <boost/throw_exception.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+struct wlcs::ExtForeignToplevelHandleV1::Impl
+{
+    Impl(ext_foreign_toplevel_handle_v1* handle);
+
+    WlHandle<ext_foreign_toplevel_handle_v1> const handle;
+    bool dirty{false};
+    bool closed{false};
+    std::optional<std::string> title;
+    std::optional<std::string> app_id;
+    std::optional<std::string> identifier;
+};
+
+wlcs::ExtForeignToplevelHandleV1::Impl::Impl(ext_foreign_toplevel_handle_v1* handle)
+    : handle{handle}
+{
+    static ext_foreign_toplevel_handle_v1_listener const listener = {
+        .closed = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->closed = true;
+                self->dirty = false;
+            },
+        .done = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->dirty = false;
+            },
+        .title = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*,
+            char const* title)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->title = title;
+                self->dirty = true;
+            },
+        .app_id = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*,
+            char const* app_id)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->app_id = app_id;
+                self->dirty = true;
+            },
+        .identifier = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*,
+            char const* identifier)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->identifier = identifier;
+                self->dirty = true;
+            },
+    };
+    ext_foreign_toplevel_handle_v1_add_listener(handle, &listener, this);
+}
+
+wlcs::ExtForeignToplevelHandleV1::ExtForeignToplevelHandleV1(
+    ext_foreign_toplevel_handle_v1 *handle)
+    : impl{std::make_unique<Impl>(handle)}
+{
+}
+
+wlcs::ExtForeignToplevelHandleV1::~ExtForeignToplevelHandleV1() = default;
+
+auto wlcs::ExtForeignToplevelHandleV1::is_dirty() const -> bool
+{
+    return impl->dirty;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::closed() const -> bool
+{
+    return impl->closed;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::title() const -> std::optional<std::string>
+{
+    return impl->title;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::app_id() const -> std::optional<std::string>
+{
+    return impl->app_id;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::identifier() const -> std::optional<std::string>
+{
+    return impl->identifier;
+}
+
+wlcs::ExtForeignToplevelHandleV1::operator ext_foreign_toplevel_handle_v1*() const
+{
+    return impl->handle;
+}
+
+struct wlcs::ExtForeignToplevelListV1::Impl {
+    Impl(Client& client);
+
+    WlHandle<ext_foreign_toplevel_list_v1> const list;
+    std::vector<std::unique_ptr<ExtForeignToplevelHandleV1>> toplevels;
+};
+
+wlcs::ExtForeignToplevelListV1::Impl::Impl(Client& client)
+    : list{client.bind_if_supported<ext_foreign_toplevel_list_v1>(wlcs::AnyVersion)}
+{
+    static ext_foreign_toplevel_list_v1_listener const listener = {
+        .toplevel = [](
+            void* data,
+            ext_foreign_toplevel_list_v1*,
+            ext_foreign_toplevel_handle_v1* toplevel)
+            {
+                auto self = static_cast<Impl*>(data);
+                auto handle = std::make_unique<ExtForeignToplevelHandleV1>(toplevel);
+                self->toplevels.push_back(std::move(handle));
+            },
+        .finished = [](
+            void* /*data*/,
+            ext_foreign_toplevel_list_v1 *)
+            {
+            },
+    };
+    ext_foreign_toplevel_list_v1_add_listener(list, &listener, this);
+}
+
+wlcs::ExtForeignToplevelListV1::ExtForeignToplevelListV1(Client& client)
+    : impl{std::make_unique<Impl>(client)}
+{
+}
+
+wlcs::ExtForeignToplevelListV1::~ExtForeignToplevelListV1() = default;
+
+auto wlcs::ExtForeignToplevelListV1::toplevels() const -> std::vector<std::unique_ptr<ExtForeignToplevelHandleV1>> const&
+{
+    return impl->toplevels;
+}
+
+auto wlcs::ExtForeignToplevelListV1::toplevel() const -> ExtForeignToplevelHandleV1 const&
+{
+    if (impl->toplevels.empty())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Manager does not know about any toplevels"));
+    if (impl->toplevels.size() > 1u)
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Manager knows about " + std::to_string(impl->toplevels.size()) + " toplevels"));
+    if (impl->toplevels[0]->is_dirty())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
+    return *impl->toplevels[0];
+}
+
+auto wlcs::ExtForeignToplevelListV1::toplevel(std::string const& app_id) const -> ExtForeignToplevelHandleV1 const&
+{
+    std::optional<ExtForeignToplevelHandleV1 const*> match;
+
+    for (auto const& i : impl->toplevels)
+    {
+        if (i->app_id() == app_id)
+        {
+            if (match)
+                BOOST_THROW_EXCEPTION(std::runtime_error("Multiple toplevels have the same app ID " + app_id));
+            else
+                match = i.get();
+        }
+    }
+    if (!match)
+        BOOST_THROW_EXCEPTION(std::runtime_error("No toplevels have the app ID " + app_id));
+    if (match.value()->is_dirty())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
+    return *match.value();
+}
+
+void wlcs::ExtForeignToplevelListV1::remove(ExtForeignToplevelHandleV1 const& toplevel)
+{
+    impl->toplevels.erase(std::remove_if(impl->toplevels.begin(), impl->toplevels.end(),
+        [&toplevel](auto const& item)
+            {
+                return item.get() == &toplevel;
+            }), impl->toplevels.end());
+}

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -2049,10 +2049,15 @@ public:
         return surface_;
     }
 
+    void attach_buffer(ShmBuffer const& buffer)
+    {
+        wl_surface_attach(surface_, buffer, 0, 0);
+    }
+
     void attach_buffer(int width, int height)
     {
         auto& buffer = owner_.create_buffer(width, height);
-        wl_surface_attach(surface_, buffer, 0, 0);
+        attach_buffer(buffer);
     }
 
     void add_frame_callback(std::function<void(uint32_t)> const& on_frame)
@@ -2067,13 +2072,19 @@ public:
         wl_callback_add_listener(callback, &frame_listener, holder.release());
     }
 
-    void attach_visible_buffer(int width, int height)
+    void attach_visible_buffer(ShmBuffer const& buffer)
     {
-        attach_buffer(width, height);
+        attach_buffer(buffer);
         auto surface_rendered = std::make_shared<bool>(false);
         add_frame_callback([surface_rendered](auto) { *surface_rendered = true; });
         wl_surface_commit(surface_);
         owner_.dispatch_until([surface_rendered]() { return *surface_rendered; });
+    }
+
+    void attach_visible_buffer(int width, int height)
+    {
+        auto& buffer = owner_.create_buffer(width, height);
+        attach_visible_buffer(buffer);
     }
 
     void run_on_destruction(std::function<void()> callback)
@@ -2188,6 +2199,11 @@ wlcs::Surface::operator ::wl_surface*() const
     return impl->surface();
 }
 
+void wlcs::Surface::attach_buffer(ShmBuffer const& buffer)
+{
+    impl->attach_buffer(buffer);
+}
+
 void wlcs::Surface::attach_buffer(int width, int height)
 {
     impl->attach_buffer(width, height);
@@ -2196,6 +2212,11 @@ void wlcs::Surface::attach_buffer(int width, int height)
 void wlcs::Surface::add_frame_callback(std::function<void(int)> const& on_frame)
 {
     impl->add_frame_callback(on_frame);
+}
+
+void wlcs::Surface::attach_visible_buffer(ShmBuffer const& buffer)
+{
+    impl->attach_visible_buffer(buffer);
 }
 
 void wlcs::Surface::attach_visible_buffer(int width, int height)

--- a/tests/ext_foreign_toplevel_list_v1.cpp
+++ b/tests/ext_foreign_toplevel_list_v1.cpp
@@ -17,181 +17,18 @@
 #include "version_specifier.h"
 #include "in_process_server.h"
 #include "xdg_shell_stable.h"
-#include "generated/ext-foreign-toplevel-list-v1-client.h"
+#include "ext_foreign_toplevel_list_v1.h"
 
-#include <boost/throw_exception.hpp>
 #include <gmock/gmock.h>
 
 #include <algorithm>
 
 using namespace testing;
 
-namespace wlcs
-{
-WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_list_v1)
-WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_handle_v1)
-}
 
 namespace
 {
 int const w = 10, h = 15;
-
-class ForeignToplevelHandle
-{
-public:
-    ForeignToplevelHandle(ext_foreign_toplevel_handle_v1* handle);
-    ForeignToplevelHandle(ForeignToplevelHandle const&) = delete;
-    ForeignToplevelHandle& operator=(ForeignToplevelHandle const&) = delete;
-
-    auto is_dirty() const { return dirty_; }
-    auto closed() const { return closed_; }
-    auto title() const { return title_; }
-    auto app_id() const { return app_id_; }
-    auto identifier() const { return identifier_; }
-
-    operator ext_foreign_toplevel_handle_v1*() const { return handle; }
-
-private:
-    wlcs::WlHandle<ext_foreign_toplevel_handle_v1> const handle;
-    bool dirty_{false};
-    bool closed_{false};
-    std::optional<std::string> title_;
-    std::optional<std::string> app_id_;
-    std::optional<std::string> identifier_;
-};
-
-ForeignToplevelHandle::ForeignToplevelHandle(ext_foreign_toplevel_handle_v1* handle)
-    : handle{handle}
-{
-    static ext_foreign_toplevel_handle_v1_listener const listener = {
-        .closed = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->closed_ = true;
-                self->dirty_ = false;
-            },
-        .done = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->dirty_ = false;
-            },
-        .title = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*,
-            char const* title)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->title_ = title;
-                self->dirty_ = true;
-            },
-        .app_id = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*,
-            char const* app_id)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->app_id_ = app_id;
-                self->dirty_ = true;
-            },
-        .identifier = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*,
-            char const* identifier)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->identifier_ = identifier;
-                self->dirty_ = true;
-            },
-    };
-    ext_foreign_toplevel_handle_v1_add_listener(handle, &listener, this);
-}
-
-class ForeignToplevelList
-{
-public:
-    ForeignToplevelList(wlcs::Client& client);
-
-    auto toplevels() -> std::vector<std::unique_ptr<ForeignToplevelHandle>> const&
-    {
-        return toplevels_;
-    }
-
-    auto toplevel() const -> ForeignToplevelHandle const&;
-    auto toplevel(std::string const& app_id) const -> ForeignToplevelHandle const&;
-    void remove(ForeignToplevelHandle const& toplevel);
-
-private:
-    wlcs::WlHandle<ext_foreign_toplevel_list_v1> const list;
-    std::vector<std::unique_ptr<ForeignToplevelHandle>> toplevels_;
-};
-
-ForeignToplevelList::ForeignToplevelList(wlcs::Client& client)
-    : list{client.bind_if_supported<ext_foreign_toplevel_list_v1>(wlcs::AnyVersion)}
-{
-    static ext_foreign_toplevel_list_v1_listener const listener = {
-        .toplevel = [](
-            void* data,
-            ext_foreign_toplevel_list_v1*,
-            ext_foreign_toplevel_handle_v1* toplevel)
-            {
-                auto self = static_cast<ForeignToplevelList*>(data);
-                auto handle = std::make_unique<ForeignToplevelHandle>(toplevel);
-                self->toplevels_.push_back(std::move(handle));
-            },
-        .finished = [](
-            void* /*data*/,
-            ext_foreign_toplevel_list_v1 *)
-            {
-            },
-    };
-    ext_foreign_toplevel_list_v1_add_listener(list, &listener, this);
-}
-
-auto ForeignToplevelList::toplevel() const -> ForeignToplevelHandle const&
-{
-    if (toplevels_.empty())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Manager does not know about any toplevels"));
-    if (toplevels_.size() > 1u)
-        BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Manager knows about " + std::to_string(toplevels_.size()) + " toplevels"));
-    if (toplevels_[0]->is_dirty())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
-    return *toplevels_[0];
-}
-
-auto ForeignToplevelList::toplevel(std::string const& app_id) const -> ForeignToplevelHandle const&
-{
-    std::optional<ForeignToplevelHandle const*> match;
-
-    for (auto const& i : toplevels_)
-    {
-        if (i->app_id() == app_id)
-        {
-            if (match)
-                BOOST_THROW_EXCEPTION(std::runtime_error("Multiple toplevels have the same app ID " + app_id));
-            else
-                match = i.get();
-        }
-    }
-    if (!match)
-        BOOST_THROW_EXCEPTION(std::runtime_error("No toplevels have the app ID " + app_id));
-    if (match.value()->is_dirty())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
-    return *match.value();
-}
-
-void ForeignToplevelList::remove(ForeignToplevelHandle const& toplevel)
-{
-    toplevels_.erase(std::remove_if(toplevels_.begin(), toplevels_.end(),
-        [&toplevel](auto const& item)
-            {
-                return item.get() == &toplevel;
-            }), toplevels_.end());
-}
 
 struct Window {
     Window(wlcs::Client& client)
@@ -222,7 +59,7 @@ public:
 
 TEST_F(ExtForeignToplevelListTest, does_not_detect_toplevels_when_test_creates_none)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(0u));
 }
@@ -231,7 +68,7 @@ TEST_F(ExtForeignToplevelListTest, detects_toplevel_from_same_client)
 {
     auto const surface{client.create_visible_surface(w, h)};
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(1u));
 }
@@ -242,14 +79,14 @@ TEST_F(ExtForeignToplevelListTest, detects_toplevel_from_different_client)
 
     auto const surface{client.create_visible_surface(w, h)};
 
-    ForeignToplevelList list{observer_client};
+    wlcs::ExtForeignToplevelListV1 list{observer_client};
     observer_client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(1u));
 }
 
 TEST_F(ExtForeignToplevelListTest, detects_toplevel_created_after_list)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(0u));
 
@@ -266,7 +103,7 @@ TEST_F(ExtForeignToplevelListTest, detects_multiple_toplevels_from_multiple_clie
     auto const surface{client.create_visible_surface(w, h)};
     auto const observer_surface{observer_client.create_visible_surface(w, h)};
 
-    ForeignToplevelList list{observer_client};
+    wlcs::ExtForeignToplevelListV1 list{observer_client};
     observer_client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(2u));
 }
@@ -275,7 +112,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_title)
 {
     std::string const title = "Test Title @!\\-";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_title(win.xdg_toplevel, title.c_str());
     win.surface.attach_visible_buffer(w, h);
@@ -290,7 +127,7 @@ TEST_F(ExtForeignToplevelListTest, title_gets_updated)
     std::string const title_a = "Test Title @!\\-";
     std::string const title_b = "Title 2";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_title(win.xdg_toplevel, title_a.c_str());
     win.surface.attach_visible_buffer(w, h);
@@ -311,7 +148,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_app_id)
 {
     std::string const app_id = "fake.wlcs.app.id";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_app_id(win.xdg_toplevel, app_id.c_str());
     win.surface.attach_visible_buffer(w, h);
@@ -323,7 +160,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_app_id)
 
 TEST_F(ExtForeignToplevelListTest, handle_gets_identifier)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     win.surface.attach_visible_buffer(w, h);
     client.roundtrip();
@@ -334,7 +171,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_identifier)
 
 TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_lists)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
 
     // Create and destroy a few windows to ensure we're not just
     // testing the first window gets the same identifier.
@@ -355,7 +192,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_lists)
     ASSERT_THAT((bool)list.toplevel(app_id).identifier(), Eq(true));
     auto const identifier = list.toplevel(app_id).identifier().value();
 
-    ForeignToplevelList list2{client};
+    wlcs::ExtForeignToplevelListV1 list2{client};
     client.roundtrip();
     ASSERT_THAT(list2.toplevels().size(), Eq(1u));
     EXPECT_THAT(list2.toplevels()[0]->identifier(), Eq(identifier));
@@ -363,7 +200,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_lists)
 
 TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_clients)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
 
     // Create and destroy a few windows to ensure we're not just
     // testing the first window gets the same identifier.
@@ -385,7 +222,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_clients)
     auto const identifier = list.toplevel(app_id).identifier().value();
 
     wlcs::Client client2{the_server()};
-    ForeignToplevelList list2{client2};
+    wlcs::ExtForeignToplevelListV1 list2{client2};
     client2.roundtrip();
     ASSERT_THAT(list2.toplevels().size(), Eq(1u));
     EXPECT_THAT(list2.toplevels()[0]->identifier(), Eq(identifier));
@@ -393,7 +230,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_clients)
 
 TEST_F(ExtForeignToplevelListTest, detects_toplevel_closed)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     EXPECT_THAT(list.toplevels().size(), Eq(0u));
 
@@ -414,7 +251,7 @@ TEST_F(ExtForeignToplevelListTest, can_destroy_handles)
     std::string const title_a = "Title A";
     std::string const title_b = "Title B";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_title(win.xdg_toplevel, title_a.c_str());
     win.surface.attach_visible_buffer(w, h);

--- a/tests/ext_image_copy_capture_v1.cpp
+++ b/tests/ext_image_copy_capture_v1.cpp
@@ -17,9 +17,11 @@
 #include "geometry/rectangle.h"
 #include "geometry/size.h"
 #include "in_process_server.h"
+#include "ext_foreign_toplevel_list_v1.h"
 #include "version_specifier.h"
 #include "wl_interface_descriptor.h"
 #include "expect_protocol_error.h"
+#include "xdg_shell_stable.h"
 #include "generated/ext-image-capture-source-v1-client.h"
 #include "generated/ext-image-copy-capture-v1-client.h"
 
@@ -28,7 +30,9 @@
 
 using namespace testing;
 
-namespace wlcs {
+namespace wlcs
+{
+WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_image_capture_source_manager_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_output_image_capture_source_manager_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_capture_source_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_copy_capture_manager_v1)
@@ -37,7 +41,8 @@ WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_copy_capture_cursor_session_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_copy_capture_frame_v1)
 } // namespace wlcs
 
-namespace {
+namespace
+{
 
 class ImageCopyCaptureFrame
 {
@@ -275,6 +280,8 @@ public:
     wlcs::Client client;
 };
 
+} // namespace
+
 TEST_F(ExtImageCopyCaptureTest, can_create_source_from_output)
 {
     auto manager = client.bind_if_supported<ext_output_image_capture_source_manager_v1>(wlcs::AnyVersion);
@@ -289,6 +296,31 @@ TEST_F(ExtImageCopyCaptureTest, can_create_session_from_output)
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     auto output = client.output_state(0);
     auto source = wlcs::wrap_wl_object(ext_output_image_capture_source_manager_v1_create_source(source_manager, output.output));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    EXPECT_THAT(session.buffer_size(), Ne(std::nullopt));
+}
+
+TEST_F(ExtImageCopyCaptureTest, can_create_source_from_toplevel)
+{
+    auto manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto surface = client.create_visible_surface(100, 100);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    client.roundtrip();
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(manager, list.toplevel()));
+    client.roundtrip();
+}
+
+TEST_F(ExtImageCopyCaptureTest, can_create_session_from_toplevel)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    auto surface = client.create_visible_surface(100, 100);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    client.roundtrip();
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
     ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
     client.roundtrip();
 
@@ -565,4 +597,202 @@ TEST_F(ExtImageCopyCaptureTest, cursor_session_captures_pointer_image)
     }
 }
 
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_succeeds)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = client.create_visible_surface(100, 100);
+
+    // Attach our own buffer
+    wlcs::ShmBuffer surface_buffer{client, 100, 100};
+    memset(surface_buffer.data().data(), 0x7f, surface_buffer.data().size());
+    surface.attach_visible_buffer(surface_buffer);
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    wlcs::ShmBuffer shm_buffer{
+        client,
+        buffer_size.width.as_int(),
+        buffer_size.height.as_int(),
+    };
+    auto data = shm_buffer.data();
+    memset(data.data(), 0, data.size());
+
+    ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+    ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+    ext_image_copy_capture_frame_v1_capture(frame);
+    client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+
+    ASSERT_THAT(frame.is_ready(), IsTrue());
+    // At least one byte of the buffer should contain the bytes we
+    // wrote the surface's buffer. It might not exactly match the
+    // original due to being composited to an opaque buffer.
+    EXPECT_THAT(data, Contains(Eq(std::byte{0x7f})));
+
+    // First frame should damage the entire buffer
+    EXPECT_THAT(frame.damage(), ElementsAre(wlcs::Rectangle{{0, 0}, buffer_size}));
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_second_frame)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = client.create_visible_surface(100, 100);
+
+    // Attach our own buffer
+    wlcs::ShmBuffer surface_buffer1{client, 100, 100};
+    memset(surface_buffer1.data().data(), 0x7f, surface_buffer1.data().size());
+    surface.attach_visible_buffer(surface_buffer1);
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    wlcs::ShmBuffer shm_buffer{
+        client,
+        buffer_size.width.as_int(),
+        buffer_size.height.as_int(),
+    };
+
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x7f})));
+    }
+
+    // Start a second frame capture, then commit a new buffer
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+
+        wlcs::ShmBuffer new_buffer{client, 100, 100};
+        memset(new_buffer.data().data(), 0x8f, new_buffer.data().size());
+        surface.attach_visible_buffer(new_buffer);
+
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x8f})));
+    }
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_continues_after_minimize)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+    wlcs::XdgToplevelStable xdg_toplevel{xdg_surface};
+
+    // Attach our own buffer
+    wlcs::ShmBuffer surface_buffer1{client, 100, 100};
+    memset(surface_buffer1.data().data(), 0x7f, surface_buffer1.data().size());
+    surface.attach_visible_buffer(surface_buffer1);
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    wlcs::ShmBuffer shm_buffer{
+        client,
+        buffer_size.width.as_int(),
+        buffer_size.height.as_int(),
+    };
+
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x7f})));
+    }
+
+    // Minimize the toplevel
+    xdg_toplevel_set_minimized(xdg_toplevel);
+    client.roundtrip();
+
+    // Start a second frame capture, then commit a new buffer
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+
+        wlcs::ShmBuffer new_buffer{client, 100, 100};
+        memset(new_buffer.data().data(), 0x8f, new_buffer.data().size());
+        surface.attach_visible_buffer(new_buffer);
+
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x8f})));
+    }
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_handles_resize)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = client.create_visible_surface(100, 100);
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    // New buffer constraints are sent after the toplevel is resized
+    surface.attach_visible_buffer(200, 200);
+    client.dispatch_until([&session, buffer_size]() { return !session.is_dirty() && session.buffer_size() != buffer_size; });
+    EXPECT_THAT(session.buffer_size(), Eq(wlcs::Size{buffer_size.width*2, buffer_size.height*2}));
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_session_stops_on_surface_destroy)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = std::make_unique<wlcs::Surface>(client.create_visible_surface(100, 100));
+    client.roundtrip();
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    EXPECT_THAT(session.stopped(), IsFalse());
+
+    // Destroying the surface will stop the capture session
+    surface.reset();
+    client.dispatch_until([&session]() { return session.stopped(); });
 }

--- a/tests/ext_image_copy_capture_v1.cpp
+++ b/tests/ext_image_copy_capture_v1.cpp
@@ -308,6 +308,8 @@ TEST_F(ExtImageCopyCaptureTest, can_create_source_from_toplevel)
     auto manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
     auto surface = client.create_visible_surface(100, 100);
     wlcs::ExtForeignToplevelListV1 list{client};
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
     client.roundtrip();
     auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(manager, list.toplevel()));
     client.roundtrip();
@@ -319,7 +321,7 @@ TEST_F(ExtImageCopyCaptureTest, can_create_session_from_toplevel)
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     auto surface = client.create_visible_surface(100, 100);
     wlcs::ExtForeignToplevelListV1 list{client};
-    client.roundtrip();
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
     auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
     ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
     client.roundtrip();
@@ -603,6 +605,7 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_succeeds)
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     wlcs::ExtForeignToplevelListV1 list{client};
     auto surface = client.create_visible_surface(100, 100);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
 
     // Attach our own buffer
     wlcs::ShmBuffer surface_buffer{client, 100, 100};
@@ -648,6 +651,7 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_second_frame)
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     wlcs::ExtForeignToplevelListV1 list{client};
     auto surface = client.create_visible_surface(100, 100);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
 
     // Attach our own buffer
     wlcs::ShmBuffer surface_buffer1{client, 100, 100};
@@ -731,6 +735,7 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_continues_after_minimize)
     wlcs::ShmBuffer surface_buffer1{client, 100, 100};
     memset(surface_buffer1.data().data(), 0x7f, surface_buffer1.data().size());
     surface.attach_visible_buffer(surface_buffer1);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
 
     auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
     ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
@@ -783,6 +788,7 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_handles_resize)
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     wlcs::ExtForeignToplevelListV1 list{client};
     auto surface = client.create_visible_surface(100, 100);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
 
     auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
     ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
@@ -797,6 +803,8 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_handles_resize)
     // New buffer constraints are sent after the toplevel is resized
     surface.attach_visible_buffer(200, 200);
     client.dispatch_until([&session, buffer_size]() { return !session.is_dirty() && session.buffer_size() != buffer_size; });
+    // This will probably be 200x200, but could potentially be
+    // scaled. So check that it is double the previous buffer size.
     EXPECT_THAT(session.buffer_size(), Eq(wlcs::Size{buffer_size.width*2, buffer_size.height*2}));
 }
 
@@ -806,7 +814,7 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_session_stops_on_surface_destro
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     wlcs::ExtForeignToplevelListV1 list{client};
     auto surface = std::make_unique<wlcs::Surface>(client.create_visible_surface(100, 100));
-    client.roundtrip();
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
 
     auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
     ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};

--- a/tests/ext_image_copy_capture_v1.cpp
+++ b/tests/ext_image_copy_capture_v1.cpp
@@ -700,9 +700,32 @@ TEST_F(ExtImageCopyCaptureTest, toplevel_capture_continues_after_minimize)
     auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     wlcs::ExtForeignToplevelListV1 list{client};
+
+    // Create a surface we can minimize
     wlcs::Surface surface{client};
     wlcs::XdgSurfaceStable xdg_surface{client, surface};
     wlcs::XdgToplevelStable xdg_toplevel{xdg_surface};
+
+    // ack the initial xdg_surface configure
+    bool initial_configure_received = false;
+    EXPECT_CALL(xdg_surface, configure(_))
+        .WillOnce([&initial_configure_received, &xdg_surface](uint32_t serial)
+            {
+                xdg_surface_ack_configure(xdg_surface, serial);
+                initial_configure_received = true;
+            });
+    wl_surface_commit(surface);
+    client.dispatch_until([&]() { return initial_configure_received; });
+    Mock::VerifyAndClearExpectations(&xdg_surface);
+
+    // Ack any future configure events
+    EXPECT_CALL(xdg_surface, configure(_))
+        .Times(AnyNumber())
+        .WillRepeatedly(
+            [xdg_surface=static_cast<struct xdg_surface*>(xdg_surface)](uint32_t serial)
+            {
+                xdg_surface_ack_configure(xdg_surface, serial);
+            });
 
     // Attach our own buffer
     wlcs::ShmBuffer surface_buffer1{client, 100, 100};


### PR DESCRIPTION
This adds some basic tests for image capture from toplevels:

* Capture sources can be created from toplevels
* Capture sessions can be created from the above source.
* Capturing a frame from the session returns data that looks like it comes from the surface's buffer.
* A new frame is offered for capture when a new buffer is committed to the surface.
* The session reports buffer constraints changes when the surface is resized.
* Frames can be captured when the toplevel is minimised.
* The capture session sends the stopped event when it's corresponding surface is destroyed.

Related: https://github.com/canonical/mir/pull/5002