### PR TITLE
Add wl_registry conformance tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ option(WLCS_BUILD_UBSAN "Build a test runner with UndefinedBehaviourSanitizer an
 set(WLCS_TESTS
   tests/test_bad_buffer.cpp
   tests/wl_shm.cpp
+  tests/wl_registry.cpp
   tests/pointer_constraints.cpp
   tests/copy_cut_paste.cpp
   tests/gtk_primary_selection.cpp

--- a/src/protocol/wayland.xml
+++ b/src/protocol/wayland.xml
@@ -2832,4 +2832,31 @@
     </request>
   </interface>
 
+  <interface name="wl_fixes" version="1">
+    <description summary="wayland protocol fixes">
+      This global fixes problems with other core-protocol interfaces that
+      cannot be fixed in these interfaces themselves.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroys this object"/>
+    </request>
+
+    <request name="destroy_registry">
+      <description summary="destroy a wl_registry">
+	This request destroys a wl_registry object.
+
+	The client should no longer use the wl_registry after making this
+	request.
+
+	The compositor will emit a wl_display.delete_id event with the object ID
+	of the registry and will no longer emit any events on the registry. The
+	client should re-use the object ID once it receives the
+	wl_display.delete_id event.
+      </description>
+      <arg name="registry" type="object" interface="wl_registry"
+	   summary="the registry to destroy"/>
+    </request>
+  </interface>
+
 </protocol>

--- a/tests/wl_registry.cpp
+++ b/tests/wl_registry.cpp
@@ -105,29 +105,20 @@ TEST_F(RegistryTest, registry_can_be_destroyed_with_wl_fixes)
     // Destroy a separate registry via wl_fixes; the client must not use it after.
     auto doomed_registry = wl_display_get_registry(client);
     client.roundtrip();
-
     auto const doomed_id = wl_proxy_get_id(reinterpret_cast<wl_proxy*>(doomed_registry));
-
     wl_fixes_destroy_registry(fixes, doomed_registry);
-
-    // A clean roundtrip confirms the server processed the destroy without error.
     client.roundtrip();
-
-    // wl_registry has no destructor request, so this only frees the local proxy.
-    // libwayland only releases the object ID for re-use once the server has sent
-    // the wl_display.delete_id event for it, so destroying the proxy now (after
-    // the roundtrip above) makes the ID reusable iff delete_id was emitted.
-    wl_registry_destroy(doomed_registry);
 
     // The compositor must emit wl_display.delete_id for the destroyed registry.
     // We cannot observe delete_id directly (libwayland handles it internally), but
     // a freed ID is re-used by the next object the client creates. If delete_id had
     // not been emitted, the ID would remain reserved and a fresh ID would be used.
+    wl_registry_destroy(doomed_registry);
     auto reused_registry = wl_display_get_registry(client);
     EXPECT_THAT(wl_proxy_get_id(reinterpret_cast<wl_proxy*>(reused_registry)), Eq(doomed_id))
         << "Compositor did not emit wl_display.delete_id for the destroyed registry";
-
     wl_registry_destroy(reused_registry);
+
     wl_fixes_destroy(fixes);
     wl_registry_destroy(registry);
 }

--- a/tests/wl_registry.cpp
+++ b/tests/wl_registry.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2024 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "in_process_server.h"
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace testing;
+
+namespace
+{
+struct AdvertisedGlobal
+{
+    uint32_t name;
+    std::string interface;
+    uint32_t version;
+};
+
+struct RegistryTest : wlcs::StartedInProcessServer
+{
+    wlcs::Client client{the_server()};
+
+    /// Creates a fresh registry and gathers every global the server advertises.
+    std::vector<AdvertisedGlobal> enumerate_globals(wl_registry* registry)
+    {
+        globals.clear();
+
+        static wl_registry_listener const listener{
+            [](void* data, wl_registry*, uint32_t name, char const* interface, uint32_t version)
+            {
+                auto& globals = *static_cast<std::vector<AdvertisedGlobal>*>(data);
+                globals.push_back({name, interface, version});
+            },
+            [](void*, wl_registry*, uint32_t) {}};
+
+        wl_registry_add_listener(registry, &listener, &globals);
+        client.roundtrip();
+
+        return globals;
+    }
+
+    std::vector<AdvertisedGlobal> globals;
+};
+
+std::vector<std::string> interface_names(std::vector<AdvertisedGlobal> const& globals)
+{
+    std::vector<std::string> names;
+    for (auto const& global : globals)
+        names.push_back(global.interface);
+    return names;
+}
+}
+
+// wl_display.get_registry must return a registry that advertises the server's globals.
+TEST_F(RegistryTest, get_registry_returns_globals)
+{
+    auto registry = wl_display_get_registry(client);
+
+    auto const globals = enumerate_globals(registry);
+
+    EXPECT_THAT(globals, Not(IsEmpty()));
+    // Every conformant compositor must expose these core globals.
+    EXPECT_THAT(interface_names(globals), Contains(Eq("wl_compositor")));
+    EXPECT_THAT(interface_names(globals), Contains(Eq("wl_shm")));
+
+    wl_registry_destroy(registry);
+}
+
+// Each advertised global must be bindable via wl_registry.bind.
+TEST_F(RegistryTest, can_bind_advertised_globals)
+{
+    // Map the well-known core interfaces to the wl_interface needed to bind them.
+    static std::pair<char const*, wl_interface const*> const known_interfaces[]{
+        {"wl_compositor", &wl_compositor_interface},
+        {"wl_subcompositor", &wl_subcompositor_interface},
+        {"wl_shm", &wl_shm_interface},
+        {"wl_seat", &wl_seat_interface},
+        {"wl_output", &wl_output_interface},
+        {"wl_data_device_manager", &wl_data_device_manager_interface},
+    };
+
+    auto registry = wl_display_get_registry(client);
+
+    auto const globals = enumerate_globals(registry);
+    ASSERT_THAT(globals, Not(IsEmpty()));
+
+    std::vector<wl_proxy*> bound;
+    bool bound_any = false;
+    for (auto const& global : globals)
+    {
+        auto const known = std::find_if(
+            std::begin(known_interfaces), std::end(known_interfaces),
+            [&](auto const& entry) { return global.interface == entry.first; });
+        if (known == std::end(known_interfaces))
+            continue;
+
+        auto const version = std::min(global.version, static_cast<uint32_t>(known->second->version));
+        auto proxy = static_cast<wl_proxy*>(
+            wl_registry_bind(registry, global.name, known->second, version));
+
+        EXPECT_THAT(proxy, NotNull()) << "Failed to bind " << global.interface;
+        if (proxy)
+        {
+            bound.push_back(proxy);
+            bound_any = true;
+        }
+    }
+
+    EXPECT_TRUE(bound_any) << "No known core globals were advertised to bind";
+
+    // A successful roundtrip confirms the server accepted all the bind requests.
+    client.roundtrip();
+
+    for (auto proxy : bound)
+        wl_proxy_destroy(proxy);
+    wl_registry_destroy(registry);
+}
+
+// wl_fixes.destroy_registry provides a way to destroy a registry server-side.
+TEST_F(RegistryTest, registry_can_be_destroyed_with_wl_fixes)
+{
+    auto registry = wl_display_get_registry(client);
+    auto const globals = enumerate_globals(registry);
+
+    auto const fixes_global = std::find_if(
+        globals.begin(), globals.end(),
+        [](AdvertisedGlobal const& global) { return global.interface == "wl_fixes"; });
+
+    if (fixes_global == globals.end())
+    {
+        wl_registry_destroy(registry);
+        GTEST_SKIP() << "Compositor does not support wl_fixes";
+    }
+
+    auto fixes = static_cast<wl_fixes*>(
+        wl_registry_bind(registry, fixes_global->name, &wl_fixes_interface, 1));
+    ASSERT_THAT(fixes, NotNull());
+
+    // Destroy a separate registry via wl_fixes; the client must not use it after.
+    auto doomed_registry = wl_display_get_registry(client);
+    client.roundtrip();
+
+    wl_fixes_destroy_registry(fixes, doomed_registry);
+
+    // A clean roundtrip confirms the server processed the destroy without error.
+    client.roundtrip();
+
+    // wl_registry has no destructor request, so this only frees the local proxy
+    // (the server already destroyed its side in response to wl_fixes).
+    wl_registry_destroy(doomed_registry);
+
+    wl_fixes_destroy(fixes);
+    wl_registry_destroy(registry);
+}

--- a/tests/wl_registry.cpp
+++ b/tests/wl_registry.cpp
@@ -158,15 +158,28 @@ TEST_F(RegistryTest, registry_can_be_destroyed_with_wl_fixes)
     auto doomed_registry = wl_display_get_registry(client);
     client.roundtrip();
 
+    auto const doomed_id = wl_proxy_get_id(reinterpret_cast<wl_proxy*>(doomed_registry));
+
     wl_fixes_destroy_registry(fixes, doomed_registry);
 
     // A clean roundtrip confirms the server processed the destroy without error.
     client.roundtrip();
 
-    // wl_registry has no destructor request, so this only frees the local proxy
-    // (the server already destroyed its side in response to wl_fixes).
+    // wl_registry has no destructor request, so this only frees the local proxy.
+    // libwayland only releases the object ID for re-use once the server has sent
+    // the wl_display.delete_id event for it, so destroying the proxy now (after
+    // the roundtrip above) makes the ID reusable iff delete_id was emitted.
     wl_registry_destroy(doomed_registry);
 
+    // The compositor must emit wl_display.delete_id for the destroyed registry.
+    // We cannot observe delete_id directly (libwayland handles it internally), but
+    // a freed ID is re-used by the next object the client creates. If delete_id had
+    // not been emitted, the ID would remain reserved and a fresh ID would be used.
+    auto reused_registry = wl_display_get_registry(client);
+    EXPECT_THAT(wl_proxy_get_id(reinterpret_cast<wl_proxy*>(reused_registry)), Eq(doomed_id))
+        << "Compositor did not emit wl_display.delete_id for the destroyed registry";
+
+    wl_registry_destroy(reused_registry);
     wl_fixes_destroy(fixes);
     wl_registry_destroy(registry);
 }

--- a/tests/wl_registry.cpp
+++ b/tests/wl_registry.cpp
@@ -37,7 +37,6 @@ struct RegistryTest : wlcs::StartedInProcessServer
 {
     wlcs::Client client{the_server()};
 
-    /// Creates a fresh registry and gathers every global the server advertises.
     std::vector<AdvertisedGlobal> enumerate_globals(wl_registry* registry)
     {
         globals.clear();

--- a/tests/wl_registry.cpp
+++ b/tests/wl_registry.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <string>
-#include <utility>
 #include <vector>
 
 using namespace testing;
@@ -81,56 +80,6 @@ TEST_F(RegistryTest, get_registry_returns_globals)
     EXPECT_THAT(interface_names(globals), Contains(Eq("wl_compositor")));
     EXPECT_THAT(interface_names(globals), Contains(Eq("wl_shm")));
 
-    wl_registry_destroy(registry);
-}
-
-// Each advertised global must be bindable via wl_registry.bind.
-TEST_F(RegistryTest, can_bind_advertised_globals)
-{
-    // Map the well-known core interfaces to the wl_interface needed to bind them.
-    static std::pair<char const*, wl_interface const*> const known_interfaces[]{
-        {"wl_compositor", &wl_compositor_interface},
-        {"wl_subcompositor", &wl_subcompositor_interface},
-        {"wl_shm", &wl_shm_interface},
-        {"wl_seat", &wl_seat_interface},
-        {"wl_output", &wl_output_interface},
-        {"wl_data_device_manager", &wl_data_device_manager_interface},
-    };
-
-    auto registry = wl_display_get_registry(client);
-
-    auto const globals = enumerate_globals(registry);
-    ASSERT_THAT(globals, Not(IsEmpty()));
-
-    std::vector<wl_proxy*> bound;
-    bool bound_any = false;
-    for (auto const& global : globals)
-    {
-        auto const known = std::find_if(
-            std::begin(known_interfaces), std::end(known_interfaces),
-            [&](auto const& entry) { return global.interface == entry.first; });
-        if (known == std::end(known_interfaces))
-            continue;
-
-        auto const version = std::min(global.version, static_cast<uint32_t>(known->second->version));
-        auto proxy = static_cast<wl_proxy*>(
-            wl_registry_bind(registry, global.name, known->second, version));
-
-        EXPECT_THAT(proxy, NotNull()) << "Failed to bind " << global.interface;
-        if (proxy)
-        {
-            bound.push_back(proxy);
-            bound_any = true;
-        }
-    }
-
-    EXPECT_TRUE(bound_any) << "No known core globals were advertised to bind";
-
-    // A successful roundtrip confirms the server accepted all the bind requests.
-    client.roundtrip();
-
-    for (auto proxy : bound)
-        wl_proxy_destroy(proxy);
     wl_registry_destroy(registry);
 }
 


### PR DESCRIPTION
Add tests/wl_registry.cpp verifying that wl_display.get_registry returns the server's globals and that a registry can be destroyed using wl_fixes.destroy_registry.
