### PR TITLE
Add xdg_surface configure and ack_configure tests

### DIFF
--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -33,6 +33,8 @@
 
 #include <gmock/gmock.h>
 
+#include <vector>
+
 using namespace testing;
 using XdgSurfaceStableTest = wlcs::InProcessServer;
 using wlcs::AnyVersion;
@@ -64,6 +66,269 @@ TEST_F(XdgSurfaceStableTest, gets_configure_event)
     wl_surface_commit(surface);
 
     client.dispatch_until([&configure_received]() { return configure_received;} );
+}
+
+TEST_F(XdgSurfaceStableTest, gets_multiple_configure_events)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+
+    std::vector<uint32_t> configure_serials;
+    ON_CALL(xdg_surface, configure)
+        .WillByDefault([&](auto serial)
+        {
+            xdg_surface_ack_configure(xdg_surface, serial);
+            configure_serials.push_back(serial);
+        });
+
+    wlcs::XdgToplevelStable toplevel{xdg_surface};
+    // The first commit triggers an initial xdg_surface.configure event
+    wl_surface_commit(surface);
+
+    auto const wait_for_another_configure = [&]()
+    {
+        auto const previous_count = configure_serials.size();
+        client.dispatch_until([&]() { return configure_serials.size() > previous_count; });
+    };
+
+    // Wait for the initial configure, ack it, and map the surface with a buffer.
+    wait_for_another_configure();
+    surface.attach_buffer(200, 320);
+    wl_surface_commit(surface);
+
+    // Requesting a state change causes the compositor to send a further configure.
+    xdg_toplevel_set_maximized(toplevel);
+    wait_for_another_configure();
+
+    EXPECT_THAT(configure_serials.size(), Ge(2u));
+    // Each configure event carries a distinct serial.
+    EXPECT_THAT(configure_serials.back(), Ne(configure_serials.front()));
+}
+
+TEST_F(XdgSurfaceStableTest, only_the_last_of_multiple_configures_needs_acking)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+
+    std::vector<uint32_t> configure_serials;
+    bool auto_ack{true};
+    ON_CALL(xdg_surface, configure)
+        .WillByDefault([&](auto serial)
+        {
+            configure_serials.push_back(serial);
+            if (auto_ack)
+                xdg_surface_ack_configure(xdg_surface, serial);
+        });
+
+    wlcs::XdgToplevelStable toplevel{xdg_surface};
+    // The first commit triggers an initial xdg_surface.configure event
+    wl_surface_commit(surface);
+
+    auto const wait_for_another_configure = [&]()
+    {
+        auto const previous_count = configure_serials.size();
+        client.dispatch_until([&]() { return configure_serials.size() > previous_count; });
+    };
+
+    // Map the surface, acking the initial configure as required.
+    wait_for_another_configure();
+    surface.attach_buffer(200, 320);
+    wl_surface_commit(surface);
+
+    // Stop acking so we can accumulate several un-acked configure events.
+    auto_ack = false;
+    auto const count_before_reconfigure = configure_serials.size();
+
+    // Each state change prompts the compositor to send a further configure.
+    xdg_toplevel_set_maximized(toplevel);
+    wait_for_another_configure();
+    xdg_toplevel_unset_maximized(toplevel);
+    wait_for_another_configure();
+
+    // Flush any further in-flight configure events so we know the latest serial.
+    client.roundtrip();
+
+    // We must have received multiple configure events without acking any of them.
+    ASSERT_THAT(configure_serials.size() - count_before_reconfigure, Ge(2u));
+
+    // Acknowledging only the most recent configure must be accepted: the earlier
+    // configure events do not need to be acknowledged individually.
+    xdg_surface_ack_configure(xdg_surface, configure_serials.back());
+    wl_surface_commit(surface);
+    client.roundtrip();
+}
+
+TEST_F(XdgSurfaceStableTest, ack_configure_for_an_earlier_configure_after_a_later_one_is_an_error)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+
+    std::vector<uint32_t> configure_serials;
+    bool auto_ack{true};
+    ON_CALL(xdg_surface, configure)
+        .WillByDefault([&](auto serial)
+        {
+            configure_serials.push_back(serial);
+            if (auto_ack)
+                xdg_surface_ack_configure(xdg_surface, serial);
+        });
+
+    wlcs::XdgToplevelStable toplevel{xdg_surface};
+    // The first commit triggers an initial xdg_surface.configure event
+    wl_surface_commit(surface);
+
+    auto const wait_for_another_configure = [&]()
+    {
+        auto const previous_count = configure_serials.size();
+        client.dispatch_until([&]() { return configure_serials.size() > previous_count; });
+    };
+
+    // Map the surface, acking the initial configure as required.
+    wait_for_another_configure();
+    surface.attach_buffer(200, 320);
+    wl_surface_commit(surface);
+
+    // Stop acking so we can accumulate several un-acked configure events.
+    auto_ack = false;
+    auto const first_reconfigure_index = configure_serials.size();
+
+    // Each state change prompts the compositor to send a further configure.
+    xdg_toplevel_set_maximized(toplevel);
+    wait_for_another_configure();
+    xdg_toplevel_unset_maximized(toplevel);
+    wait_for_another_configure();
+
+    // Flush any further in-flight configure events so we know the latest serial.
+    client.roundtrip();
+
+    // We need at least two distinct un-acked configure events to ack out of order.
+    ASSERT_THAT(configure_serials.size() - first_reconfigure_index, Ge(2u));
+
+    auto const earlier_serial = configure_serials.at(first_reconfigure_index);
+    auto const later_serial = configure_serials.back();
+
+    // Acking the most recent configure consumes all the earlier ones.
+    xdg_surface_ack_configure(xdg_surface, later_serial);
+    client.roundtrip();
+
+    try
+    {
+        // Acking a configure event issued before the last acked one must error.
+        xdg_surface_ack_configure(xdg_surface, earlier_serial);
+        client.roundtrip();
+    }
+    catch(wlcs::ProtocolError const& error)
+    {
+        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
+        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
+        return;
+    }
+
+    FAIL() << "Expected protocol error not received";
+}
+
+TEST_F(XdgSurfaceStableTest, ack_configure_with_invalid_serial_is_an_error)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+
+    uint32_t configure_serial{0};
+    bool configure_received{false};
+    EXPECT_CALL(xdg_surface, configure)
+        .WillOnce([&](auto serial)
+        {
+            configure_serial = serial;
+            configure_received = true;
+        });
+
+    wlcs::XdgToplevelStable toplevel{xdg_surface};
+    // The first commit triggers an initial xdg_surface.configure event
+    wl_surface_commit(surface);
+
+    client.dispatch_until([&configure_received]() { return configure_received; });
+
+    try
+    {
+        // Acking a configure event that was never sent must raise an error.
+        xdg_surface_ack_configure(xdg_surface, configure_serial + 1);
+        client.roundtrip();
+    }
+    catch(wlcs::ProtocolError const& error)
+    {
+        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
+        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
+        return;
+    }
+
+    FAIL() << "Expected protocol error not received";
+}
+
+TEST_F(XdgSurfaceStableTest, ack_configure_twice_for_same_event_is_an_error)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+
+    uint32_t configure_serial{0};
+    bool configure_received{false};
+    EXPECT_CALL(xdg_surface, configure)
+        .WillOnce([&](auto serial)
+        {
+            configure_serial = serial;
+            configure_received = true;
+        });
+
+    wlcs::XdgToplevelStable toplevel{xdg_surface};
+    // The first commit triggers an initial xdg_surface.configure event
+    wl_surface_commit(surface);
+
+    client.dispatch_until([&configure_received]() { return configure_received; });
+
+    // The first ack of the configure serial is valid.
+    xdg_surface_ack_configure(xdg_surface, configure_serial);
+    client.roundtrip();
+
+    try
+    {
+        // Acking the same configure event a second time must raise an error.
+        xdg_surface_ack_configure(xdg_surface, configure_serial);
+        client.roundtrip();
+    }
+    catch(wlcs::ProtocolError const& error)
+    {
+        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
+        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
+        return;
+    }
+
+    FAIL() << "Expected protocol error not received";
+}
+
+TEST_F(XdgSurfaceStableTest, ack_configure_without_a_configure_event_is_an_error)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+
+    // No surface commit is made, so the compositor never sends a configure
+    // event. Acking any serial must therefore raise an error.
+    try
+    {
+        xdg_surface_ack_configure(xdg_surface, 1);
+        client.roundtrip();
+    }
+    catch(wlcs::ProtocolError const& error)
+    {
+        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
+        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
+        return;
+    }
+
+    FAIL() << "Expected protocol error not received";
 }
 
 TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error)
@@ -177,3 +442,4 @@ TEST_F(XdgSurfaceStableTest, attaching_buffer_to_unconfigured_xdg_surface_is_an_
 
     FAIL() << "Expected protocol error not received";
 }
+

--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -442,4 +442,3 @@ TEST_F(XdgSurfaceStableTest, attaching_buffer_to_unconfigured_xdg_surface_is_an_
 
     FAIL() << "Expected protocol error not received";
 }
-

--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -30,6 +30,7 @@
 #include "xdg_shell_stable.h"
 #include "wl_handle.h"
 #include "version_specifier.h"
+#include "expect_protocol_error.h"
 
 #include <gmock/gmock.h>
 
@@ -101,8 +102,8 @@ TEST_F(XdgSurfaceStableTest, gets_multiple_configure_events)
     xdg_toplevel_set_maximized(toplevel);
     wait_for_another_configure();
 
-    EXPECT_THAT(configure_serials.size(), Ge(2u));
-    // Each configure event carries a distinct serial.
+    // The two waits above guarantee at least two configure events; each must
+    // carry a distinct serial.
     EXPECT_THAT(configure_serials.back(), Ne(configure_serials.front()));
 }
 
@@ -137,11 +138,11 @@ TEST_F(XdgSurfaceStableTest, only_the_last_of_multiple_configures_needs_acking)
     surface.attach_buffer(200, 320);
     wl_surface_commit(surface);
 
-    // Stop acking so we can accumulate several un-acked configure events.
+    // Stop acking so we accumulate several un-acked configure events.
     auto_ack = false;
-    auto const count_before_reconfigure = configure_serials.size();
 
-    // Each state change prompts the compositor to send a further configure.
+    // Each state change prompts the compositor to send a further configure. The
+    // two waits guarantee multiple un-acked configure events are accumulated.
     xdg_toplevel_set_maximized(toplevel);
     wait_for_another_configure();
     xdg_toplevel_unset_maximized(toplevel);
@@ -149,9 +150,6 @@ TEST_F(XdgSurfaceStableTest, only_the_last_of_multiple_configures_needs_acking)
 
     // Flush any further in-flight configure events so we know the latest serial.
     client.roundtrip();
-
-    // We must have received multiple configure events without acking any of them.
-    ASSERT_THAT(configure_serials.size() - count_before_reconfigure, Ge(2u));
 
     // Acknowledging only the most recent configure must be accepted: the earlier
     // configure events do not need to be acknowledged individually.
@@ -191,43 +189,29 @@ TEST_F(XdgSurfaceStableTest, ack_configure_for_an_earlier_configure_after_a_late
     surface.attach_buffer(200, 320);
     wl_surface_commit(surface);
 
-    // Stop acking so we can accumulate several un-acked configure events.
+    // Stop acking so we can ack the following configure events out of order.
     auto_ack = false;
-    auto const first_reconfigure_index = configure_serials.size();
 
     // Each state change prompts the compositor to send a further configure.
     xdg_toplevel_set_maximized(toplevel);
     wait_for_another_configure();
+    auto const earlier_serial = configure_serials.back();
+
     xdg_toplevel_unset_maximized(toplevel);
     wait_for_another_configure();
-
-    // Flush any further in-flight configure events so we know the latest serial.
-    client.roundtrip();
-
-    // We need at least two distinct un-acked configure events to ack out of order.
-    ASSERT_THAT(configure_serials.size() - first_reconfigure_index, Ge(2u));
-
-    auto const earlier_serial = configure_serials.at(first_reconfigure_index);
     auto const later_serial = configure_serials.back();
+
+    ASSERT_THAT(later_serial, Ne(earlier_serial));
 
     // Acking the most recent configure consumes all the earlier ones.
     xdg_surface_ack_configure(xdg_surface, later_serial);
     client.roundtrip();
 
-    try
-    {
-        // Acking a configure event issued before the last acked one must error.
+    // Acking a configure event issued before the last acked one must error.
+    EXPECT_PROTOCOL_ERROR({
         xdg_surface_ack_configure(xdg_surface, earlier_serial);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_surface_interface, XDG_SURFACE_ERROR_INVALID_SERIAL);
 }
 
 TEST_F(XdgSurfaceStableTest, ack_configure_with_invalid_serial_is_an_error)
@@ -251,20 +235,11 @@ TEST_F(XdgSurfaceStableTest, ack_configure_with_invalid_serial_is_an_error)
 
     client.dispatch_until([&configure_received]() { return configure_received; });
 
-    try
-    {
-        // Acking a configure event that was never sent must raise an error.
+    // Acking a configure event that was never sent must raise an error.
+    EXPECT_PROTOCOL_ERROR({
         xdg_surface_ack_configure(xdg_surface, configure_serial + 1);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_surface_interface, XDG_SURFACE_ERROR_INVALID_SERIAL);
 }
 
 TEST_F(XdgSurfaceStableTest, ack_configure_twice_for_same_event_is_an_error)
@@ -292,20 +267,11 @@ TEST_F(XdgSurfaceStableTest, ack_configure_twice_for_same_event_is_an_error)
     xdg_surface_ack_configure(xdg_surface, configure_serial);
     client.roundtrip();
 
-    try
-    {
-        // Acking the same configure event a second time must raise an error.
+    // Acking the same configure event a second time must raise an error.
+    EXPECT_PROTOCOL_ERROR({
         xdg_surface_ack_configure(xdg_surface, configure_serial);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_surface_interface, XDG_SURFACE_ERROR_INVALID_SERIAL);
 }
 
 TEST_F(XdgSurfaceStableTest, ack_configure_without_a_configure_event_is_an_error)
@@ -316,19 +282,10 @@ TEST_F(XdgSurfaceStableTest, ack_configure_without_a_configure_event_is_an_error
 
     // No surface commit is made, so the compositor never sends a configure
     // event. Acking any serial must therefore raise an error.
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_surface_ack_configure(xdg_surface, 1);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_INVALID_SERIAL));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_surface_interface, XDG_SURFACE_ERROR_INVALID_SERIAL);
 }
 
 TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error)
@@ -348,19 +305,10 @@ TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_existing_
 
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_wm_base_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_WM_BASE_ERROR_ROLE));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_ROLE);
 }
 
 
@@ -375,19 +323,10 @@ TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_attached_
     wl_surface_attach(surface, buffer, 0, 0);
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_wm_base_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE);
 }
 
 TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error)
@@ -402,19 +341,10 @@ TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_committed
     wl_surface_commit(surface);
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_wm_base_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE);
 }
 
 TEST_F(XdgSurfaceStableTest, attaching_buffer_to_unconfigured_xdg_surface_is_an_error)
@@ -427,18 +357,9 @@ TEST_F(XdgSurfaceStableTest, attaching_buffer_to_unconfigured_xdg_surface_is_an_
     wlcs::ShmBuffer buffer{client, 300, 300};
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         wl_surface_attach(surface, buffer, 0, 0);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_UNCONFIGURED_BUFFER));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_surface_interface, XDG_SURFACE_ERROR_UNCONFIGURED_BUFFER);
 }


### PR DESCRIPTION
Add tests covering xdg_surface.ack_configure error handling and configure event behaviour:
- ack_configure with an invalid (never-sent) serial is an error
- ack_configure twice for the same configure event is an error
- ack_configure without any configure event is an error
- ack_configure for an earlier configure after a later one is an error
- multiple configure events are received on state changes
- only the last of multiple configure events needs acknowledging