### PR TITLE
Use EXPECT_PROTOCOL_ERROR in tests

### DIFF
--- a/tests/ext_image_copy_capture_v1.cpp
+++ b/tests/ext_image_copy_capture_v1.cpp
@@ -19,6 +19,7 @@
 #include "in_process_server.h"
 #include "version_specifier.h"
 #include "wl_interface_descriptor.h"
+#include "expect_protocol_error.h"
 #include "generated/ext-image-capture-source-v1-client.h"
 #include "generated/ext-image-copy-capture-v1-client.h"
 
@@ -305,17 +306,9 @@ TEST_F(ExtImageCopyCaptureTest, duplicate_frames_fails)
 
     ImageCopyCaptureFrame frame1{ext_image_copy_capture_session_v1_create_frame(session)};
     ImageCopyCaptureFrame frame2{ext_image_copy_capture_session_v1_create_frame(session)};
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         client.roundtrip();
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        ASSERT_THAT(err.interface(), Eq(&ext_image_copy_capture_session_v1_interface));
-        ASSERT_THAT(err.error_code(), Eq(EXT_IMAGE_COPY_CAPTURE_SESSION_V1_ERROR_DUPLICATE_FRAME));
-        return;
-    }
-    FAIL() << "Protocol error not raised";
+    }, &ext_image_copy_capture_session_v1_interface, EXT_IMAGE_COPY_CAPTURE_SESSION_V1_ERROR_DUPLICATE_FRAME);
 }
 
 TEST_F(ExtImageCopyCaptureTest, capture_with_no_buffer_fails)
@@ -328,17 +321,9 @@ TEST_F(ExtImageCopyCaptureTest, capture_with_no_buffer_fails)
 
     ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
     ext_image_copy_capture_frame_v1_capture(frame);
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         client.roundtrip();
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        ASSERT_THAT(err.interface(), Eq(&ext_image_copy_capture_frame_v1_interface));
-        ASSERT_THAT(err.error_code(), Eq(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_NO_BUFFER));
-        return;
-    }
-    FAIL() << "Protocol error not raised";
+    }, &ext_image_copy_capture_frame_v1_interface, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_NO_BUFFER);
 }
 
 TEST_F(ExtImageCopyCaptureTest, capture_with_wrong_size_fails)

--- a/tests/test_bad_buffer.cpp
+++ b/tests/test_bad_buffer.cpp
@@ -31,6 +31,7 @@
 #include "helpers.h"
 
 #include "in_process_server.h"
+#include "expect_protocol_error.h"
 
 /* tests, that attempt to crash the compositor on purpose */
 
@@ -82,20 +83,12 @@ TEST_F(BadBufferTest, test_truncated_shm_file)
 
     wl_surface_commit(surface);
 
-    try
-    {
-        // We dispatch until we receive the protocol error, or hit the timeout.
+    // We dispatch until we receive the protocol error, or hit the timeout.
+    EXPECT_PROTOCOL_ERROR({
         client.dispatch_until([]() { return false; });
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        wl_buffer_destroy(bad_buffer);
-        EXPECT_THAT(err.error_code(), Eq(WL_SHM_ERROR_INVALID_FD));
-        EXPECT_THAT(err.interface(), Eq(&wl_buffer_interface));
-        return;
-    }
+    }, &wl_buffer_interface, WL_SHM_ERROR_INVALID_FD);
 
-    FAIL() << "Expected protocol error not raised";
+    wl_buffer_destroy(bad_buffer);
 }
 
 TEST_F(BadBufferTest, client_lies_about_buffer_size)
@@ -120,22 +113,14 @@ TEST_F(BadBufferTest, client_lies_about_buffer_size)
         incorrect_stride, // Stride is in bytes, not pixels, so this is ¼ the correct value.
         WL_SHM_FORMAT_ARGB8888);
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         /* Buffer creation should fail, so all we need is for the create_buffer
          * call to be processed
          */
         client.roundtrip();
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        wl_buffer_destroy(bad_buffer);
-        EXPECT_THAT(err.error_code(), Eq(WL_SHM_ERROR_INVALID_STRIDE));
-        EXPECT_THAT(err.interface(), Eq(&wl_shm_pool_interface));
-        return;
-    }
+    }, &wl_shm_pool_interface, WL_SHM_ERROR_INVALID_STRIDE);
 
-    FAIL() << "Expected protocol error not raised";
+    wl_buffer_destroy(bad_buffer);
 }
 
 // This should be identical to the first tests case of the previous test. It tests if a 2nd instance of the server can
@@ -159,18 +144,10 @@ TEST_F(SecondBadBufferTest, test_truncated_shm_file)
 
     wl_surface_commit(surface);
 
-    try
-    {
-        // We dispatch until we receive the protocol error, or hit the timeout.
+    // We dispatch until we receive the protocol error, or hit the timeout.
+    EXPECT_PROTOCOL_ERROR({
         client.dispatch_until([]() { return false; });
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        wl_buffer_destroy(bad_buffer);
-        EXPECT_THAT(err.error_code(), Eq(WL_SHM_ERROR_INVALID_FD));
-        EXPECT_THAT(err.interface(), Eq(&wl_buffer_interface));
-        return;
-    }
+    }, &wl_buffer_interface, WL_SHM_ERROR_INVALID_FD);
 
-    FAIL() << "Expected protocol error not raised";
+    wl_buffer_destroy(bad_buffer);
 }

--- a/tests/wlr_layer_shell_v1.cpp
+++ b/tests/wlr_layer_shell_v1.cpp
@@ -22,6 +22,7 @@
 #include "xdg_shell_stable.h"
 #include "version_specifier.h"
 #include "geometry/rectangle.h"
+#include "expect_protocol_error.h"
 
 #include <gmock/gmock.h>
 
@@ -356,54 +357,30 @@ class LayerSurfaceErrorsTest:
 
 TEST_F(LayerSurfaceTest, specifying_no_size_without_anchors_is_an_error)
 {
-    try
-    {
+    // The protocol does not explicitly state what error to send here; INVALID_SIZE seems most appropriate
+    EXPECT_PROTOCOL_ERROR({
         // Protocol specifies that a size of (0,0) is the default
         commit_and_wait_for_configure();
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        EXPECT_THAT(err.interface(), Eq(&zwlr_layer_surface_v1_interface));
-        // The protocol does not explicitly state what error to send here; INVALID_SIZE seems most appropriate
-        EXPECT_THAT(err.error_code(), Eq(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE));
-        return;
-    }
-    FAIL() << "Expected protocol error not raised";
+    }, &zwlr_layer_surface_v1_interface, ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE);
 }
 
 TEST_F(LayerSurfaceTest, specifying_zero_size_without_anchors_is_an_error)
 {
-    try
-    {
+    // The protocol does not explicitly state what error to send here; INVALID_SIZE seems most appropriate
+    EXPECT_PROTOCOL_ERROR({
         zwlr_layer_surface_v1_set_size(layer_surface, 0, 0);
         commit_and_wait_for_configure();
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        EXPECT_THAT(err.interface(), Eq(&zwlr_layer_surface_v1_interface));
-        // The protocol does not explicitly state what error to send here; INVALID_SIZE seems most appropriate
-        EXPECT_THAT(err.error_code(), Eq(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE));
-        return;
-    }
-    FAIL() << "Expected protocol error not raised";
+    }, &zwlr_layer_surface_v1_interface, ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE);
 }
 
 TEST_P(LayerSurfaceErrorsTest, specifying_zero_size_without_corresponding_anchors_is_an_error)
 {
-    try
-    {
+    // The protocol does not explicitly state what error to send here; INVALID_SIZE seems most appropriate
+    EXPECT_PROTOCOL_ERROR({
         zwlr_layer_surface_v1_set_size(layer_surface, GetParam().width, GetParam().height);
         zwlr_layer_surface_v1_set_anchor(layer_surface, GetParam().anchors);
         commit_and_wait_for_configure();
-    }
-    catch (wlcs::ProtocolError const& err)
-    {
-        EXPECT_THAT(err.interface(), Eq(&zwlr_layer_surface_v1_interface));
-        // The protocol does not explicitly state what error to send here; INVALID_SIZE seems most appropriate
-        EXPECT_THAT(err.error_code(), Eq(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE));
-        return;
-    }
-    FAIL() << "Expected protocol error not raised";
+    }, &zwlr_layer_surface_v1_interface, ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -31,6 +31,8 @@
 #include "wl_handle.h"
 #include "version_specifier.h"
 
+#include "expect_protocol_error.h"
+
 #include <gmock/gmock.h>
 
 using namespace testing;
@@ -83,19 +85,10 @@ TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_existing_
 
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_wm_base_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_WM_BASE_ERROR_ROLE));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_ROLE);
 }
 
 
@@ -110,19 +103,10 @@ TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_attached_
     wl_surface_attach(surface, buffer, 0, 0);
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_wm_base_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE);
 }
 
 TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error)
@@ -137,19 +121,10 @@ TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_committed
     wl_surface_commit(surface);
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_wm_base_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE);
 }
 
 TEST_F(XdgSurfaceStableTest, attaching_buffer_to_unconfigured_xdg_surface_is_an_error)
@@ -162,18 +137,9 @@ TEST_F(XdgSurfaceStableTest, attaching_buffer_to_unconfigured_xdg_surface_is_an_
     wlcs::ShmBuffer buffer{client, 300, 300};
     client.roundtrip();
 
-    try
-    {
+    EXPECT_PROTOCOL_ERROR({
         xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
         wl_surface_attach(surface, buffer, 0, 0);
         client.roundtrip();
-    }
-    catch(wlcs::ProtocolError const& error)
-    {
-        EXPECT_THAT(error.interface(), Eq(&xdg_surface_interface));
-        EXPECT_THAT(error.error_code(), Eq(XDG_SURFACE_ERROR_UNCONFIGURED_BUFFER));
-        return;
-    }
-
-    FAIL() << "Expected protocol error not received";
+    }, &xdg_surface_interface, XDG_SURFACE_ERROR_UNCONFIGURED_BUFFER);
 }


### PR DESCRIPTION
Convert try/catch wlcs::ProtocolError blocks to the EXPECT_PROTOCOL_ERROR macro in:

- tests/ext_image_copy_capture_v1.cpp
- tests/test_bad_buffer.cpp
- tests/wlr_layer_shell_v1.cpp
- tests/xdg_surface_stable.cpp