### PR TITLE
Remove unused includes

### DIFF
--- a/include/gtk_primary_selection.h
+++ b/include/gtk_primary_selection.h
@@ -23,11 +23,8 @@
 
 #include "active_listeners.h"
 #include "wl_interface_descriptor.h"
-#include "wl_handle.h"
 
 #include <memory>
-#include <mutex>
-#include <set>
 
 namespace wlcs
 {

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -32,7 +32,6 @@
 #include <chrono>
 
 #include "helpers.h"
-#include "shared_library.h"
 #include "wl_handle.h"
 
 #include <wayland-client.h>

--- a/tests/wl_output.cpp
+++ b/tests/wl_output.cpp
@@ -16,13 +16,10 @@
  * Authored by: William Wold <william.wold@canonical.com>
  */
 
-#include "helpers.h"
 #include "in_process_server.h"
 #include "version_specifier.h"
 
 #include <gmock/gmock.h>
-
-#include <memory>
 
 using namespace testing;
 using namespace wlcs;

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -25,7 +25,6 @@
  * SOFTWARE.
  */
 
-#include "helpers.h"
 #include "in_process_server.h"
 #include "xdg_shell_stable.h"
 #include "xdg_shell_v6.h"

--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -25,7 +25,6 @@
  * SOFTWARE.
  */
 
-#include "helpers.h"
 #include "in_process_server.h"
 #include "xdg_shell_stable.h"
 #include "wl_handle.h"

--- a/tests/xdg_surface_v6.cpp
+++ b/tests/xdg_surface_v6.cpp
@@ -25,7 +25,6 @@
  * SOFTWARE.
  */
 
-#include "helpers.h"
 #include "in_process_server.h"
 #include "xdg_shell_v6.h"
 

--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -25,15 +25,12 @@
  * SOFTWARE.
  */
 
-#include "helpers.h"
 #include "in_process_server.h"
 #include "version_specifier.h"
 #include "xdg_shell_stable.h"
 #include "expect_protocol_error.h"
 
 #include <gmock/gmock.h>
-
-#include <optional>
 
 using namespace testing;
 


### PR DESCRIPTION
Drop headers that are no longer referenced by the including file:
- in_process_server.h: shared_library.h
- gtk_primary_selection.h: wl_handle.h, <mutex>, <set>
- wl_output.cpp: helpers.h, <memory>
- xdg_popup.cpp, xdg_surface_stable.cpp, xdg_surface_v6.cpp: helpers.h
- xdg_toplevel_stable.cpp: helpers.h, <optional>