### PR TITLE
Add wl_pointer cursor-role tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ set(WLCS_TESTS
   tests/wl_data_offer_gtk_primary_selection.cpp
   tests/wl_keyboard.cpp
   tests/wl_output.cpp
+  tests/wl_pointer.cpp
   tests/wl_registry.cpp
   tests/wl_shm.cpp
   tests/wl_subsurface.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(
   include/input_method.h
   include/xdg_decoration_unstable_v1.h
   include/linux_dmabuf_v1.h
+  include/ext_foreign_toplevel_list_v1.h
 
   src/data_device.cpp
   src/gtk_primary_selection.cpp
@@ -257,6 +258,7 @@ set(
   src/input_method.cpp
   src/xdg_decoration_unstable_v1.cpp
   src/linux_dmabuf_v1.cpp
+  src/ext_foreign_toplevel_list_v1.cpp
 
   ${PROTOCOL_SOURCES}
   ${WLCS_TESTS}

--- a/include/ext_foreign_toplevel_list_v1.h
+++ b/include/ext_foreign_toplevel_list_v1.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WLCS_EXT_FOREIGN_TOPLEVEL_LIST_V1_H
+#define WLCS_EXT_FOREIGN_TOPLEVEL_LIST_V1_H
+
+#include "generated/ext-foreign-toplevel-list-v1-client.h"
+#include "wl_interface_descriptor.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace wlcs
+{
+WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_list_v1)
+WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_handle_v1)
+
+class Client;
+
+class ExtForeignToplevelHandleV1
+{
+public:
+    ExtForeignToplevelHandleV1(ext_foreign_toplevel_handle_v1* handle);
+    ~ExtForeignToplevelHandleV1();
+
+    auto is_dirty() const -> bool;
+    auto closed() const -> bool;
+    auto title() const -> std::optional<std::string>;
+    auto app_id() const -> std::optional<std::string>;
+    auto identifier() const -> std::optional<std::string>;
+
+    operator ext_foreign_toplevel_handle_v1*() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> const impl;
+};
+
+class ExtForeignToplevelListV1
+{
+public:
+    ExtForeignToplevelListV1(wlcs::Client& client);
+    ~ExtForeignToplevelListV1();
+
+    auto toplevels() const -> std::vector<std::unique_ptr<ExtForeignToplevelHandleV1>> const&;
+    auto toplevel() const -> ExtForeignToplevelHandleV1 const&;
+    auto toplevel(std::string const& app_id) const -> ExtForeignToplevelHandleV1 const&;
+    void remove(ExtForeignToplevelHandleV1 const& toplevel);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> const impl;
+};
+
+}
+
+#endif /* WLCS_EXT_FOREIGN_TOPLEVEL_LIST_V1_H */

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -202,6 +202,7 @@ private:
 };
 
 class Client;
+class ShmBuffer;
 
 class Surface
 {
@@ -214,8 +215,10 @@ public:
     operator ::wl_surface*() const;
     auto wl_surface() const -> ::wl_surface* { return *this; };
 
+    void attach_buffer(ShmBuffer const& buffer);
     void attach_buffer(int width, int height);
     void add_frame_callback(std::function<void(int)> const& on_frame);
+    void attach_visible_buffer(ShmBuffer const& buffer);
     void attach_visible_buffer(int width, int height);
     void run_on_destruction(std::function<void()> callback);
 

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -338,6 +338,12 @@ public:
     void add_pointer_motion_notification(PointerMotionNotifier const& on_motion);
     void add_pointer_button_notification(PointerButtonNotifier const& on_button);
 
+    /// Move \p pointer to the absolute coordinates (x, y) and return the serial
+    /// of the resulting wl_pointer.enter event. Fails the test if no enter
+    /// event is received. The returned serial is required by many wl_pointer
+    /// requests, most notably wl_pointer.set_cursor.
+    uint32_t move_pointer_to(Pointer& pointer, int x, int y);
+
     void dispatch_until(
         std::function<bool()> const& predicate,
         std::chrono::seconds timeout = helpers::a_long_time());

--- a/src/ext_foreign_toplevel_list_v1.cpp
+++ b/src/ext_foreign_toplevel_list_v1.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ext_foreign_toplevel_list_v1.h"
+#include "in_process_server.h"
+#include "version_specifier.h"
+#include "wl_handle.h"
+
+#include <boost/throw_exception.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+struct wlcs::ExtForeignToplevelHandleV1::Impl
+{
+    Impl(ext_foreign_toplevel_handle_v1* handle);
+
+    WlHandle<ext_foreign_toplevel_handle_v1> const handle;
+    bool dirty{false};
+    bool closed{false};
+    std::optional<std::string> title;
+    std::optional<std::string> app_id;
+    std::optional<std::string> identifier;
+};
+
+wlcs::ExtForeignToplevelHandleV1::Impl::Impl(ext_foreign_toplevel_handle_v1* handle)
+    : handle{handle}
+{
+    static ext_foreign_toplevel_handle_v1_listener const listener = {
+        .closed = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->closed = true;
+                self->dirty = false;
+            },
+        .done = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->dirty = false;
+            },
+        .title = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*,
+            char const* title)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->title = title;
+                self->dirty = true;
+            },
+        .app_id = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*,
+            char const* app_id)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->app_id = app_id;
+                self->dirty = true;
+            },
+        .identifier = [](
+            void* data,
+            ext_foreign_toplevel_handle_v1*,
+            char const* identifier)
+            {
+                auto self = static_cast<Impl*>(data);
+                self->identifier = identifier;
+                self->dirty = true;
+            },
+    };
+    ext_foreign_toplevel_handle_v1_add_listener(handle, &listener, this);
+}
+
+wlcs::ExtForeignToplevelHandleV1::ExtForeignToplevelHandleV1(
+    ext_foreign_toplevel_handle_v1 *handle)
+    : impl{std::make_unique<Impl>(handle)}
+{
+}
+
+wlcs::ExtForeignToplevelHandleV1::~ExtForeignToplevelHandleV1() = default;
+
+auto wlcs::ExtForeignToplevelHandleV1::is_dirty() const -> bool
+{
+    return impl->dirty;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::closed() const -> bool
+{
+    return impl->closed;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::title() const -> std::optional<std::string>
+{
+    return impl->title;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::app_id() const -> std::optional<std::string>
+{
+    return impl->app_id;
+}
+
+auto wlcs::ExtForeignToplevelHandleV1::identifier() const -> std::optional<std::string>
+{
+    return impl->identifier;
+}
+
+wlcs::ExtForeignToplevelHandleV1::operator ext_foreign_toplevel_handle_v1*() const
+{
+    return impl->handle;
+}
+
+struct wlcs::ExtForeignToplevelListV1::Impl {
+    Impl(Client& client);
+
+    WlHandle<ext_foreign_toplevel_list_v1> const list;
+    std::vector<std::unique_ptr<ExtForeignToplevelHandleV1>> toplevels;
+};
+
+wlcs::ExtForeignToplevelListV1::Impl::Impl(Client& client)
+    : list{client.bind_if_supported<ext_foreign_toplevel_list_v1>(wlcs::AnyVersion)}
+{
+    static ext_foreign_toplevel_list_v1_listener const listener = {
+        .toplevel = [](
+            void* data,
+            ext_foreign_toplevel_list_v1*,
+            ext_foreign_toplevel_handle_v1* toplevel)
+            {
+                auto self = static_cast<Impl*>(data);
+                auto handle = std::make_unique<ExtForeignToplevelHandleV1>(toplevel);
+                self->toplevels.push_back(std::move(handle));
+            },
+        .finished = [](
+            void* /*data*/,
+            ext_foreign_toplevel_list_v1 *)
+            {
+            },
+    };
+    ext_foreign_toplevel_list_v1_add_listener(list, &listener, this);
+}
+
+wlcs::ExtForeignToplevelListV1::ExtForeignToplevelListV1(Client& client)
+    : impl{std::make_unique<Impl>(client)}
+{
+}
+
+wlcs::ExtForeignToplevelListV1::~ExtForeignToplevelListV1() = default;
+
+auto wlcs::ExtForeignToplevelListV1::toplevels() const -> std::vector<std::unique_ptr<ExtForeignToplevelHandleV1>> const&
+{
+    return impl->toplevels;
+}
+
+auto wlcs::ExtForeignToplevelListV1::toplevel() const -> ExtForeignToplevelHandleV1 const&
+{
+    if (impl->toplevels.empty())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Manager does not know about any toplevels"));
+    if (impl->toplevels.size() > 1u)
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Manager knows about " + std::to_string(impl->toplevels.size()) + " toplevels"));
+    if (impl->toplevels[0]->is_dirty())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
+    return *impl->toplevels[0];
+}
+
+auto wlcs::ExtForeignToplevelListV1::toplevel(std::string const& app_id) const -> ExtForeignToplevelHandleV1 const&
+{
+    std::optional<ExtForeignToplevelHandleV1 const*> match;
+
+    for (auto const& i : impl->toplevels)
+    {
+        if (i->app_id() == app_id)
+        {
+            if (match)
+                BOOST_THROW_EXCEPTION(std::runtime_error("Multiple toplevels have the same app ID " + app_id));
+            else
+                match = i.get();
+        }
+    }
+    if (!match)
+        BOOST_THROW_EXCEPTION(std::out_of_range("No toplevels have the app ID " + app_id));
+    if (match.value()->is_dirty())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
+    return *match.value();
+}
+
+void wlcs::ExtForeignToplevelListV1::remove(ExtForeignToplevelHandleV1 const& toplevel)
+{
+    impl->toplevels.erase(std::remove_if(impl->toplevels.begin(), impl->toplevels.end(),
+        [&toplevel](auto const& item)
+            {
+                return item.get() == &toplevel;
+            }), impl->toplevels.end());
+}

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -2049,10 +2049,15 @@ public:
         return surface_;
     }
 
+    void attach_buffer(ShmBuffer const& buffer)
+    {
+        wl_surface_attach(surface_, buffer, 0, 0);
+    }
+
     void attach_buffer(int width, int height)
     {
         auto& buffer = owner_.create_buffer(width, height);
-        wl_surface_attach(surface_, buffer, 0, 0);
+        attach_buffer(buffer);
     }
 
     void add_frame_callback(std::function<void(uint32_t)> const& on_frame)
@@ -2067,13 +2072,19 @@ public:
         wl_callback_add_listener(callback, &frame_listener, holder.release());
     }
 
-    void attach_visible_buffer(int width, int height)
+    void attach_visible_buffer(ShmBuffer const& buffer)
     {
-        attach_buffer(width, height);
+        attach_buffer(buffer);
         auto surface_rendered = std::make_shared<bool>(false);
         add_frame_callback([surface_rendered](auto) { *surface_rendered = true; });
         wl_surface_commit(surface_);
         owner_.dispatch_until([surface_rendered]() { return *surface_rendered; });
+    }
+
+    void attach_visible_buffer(int width, int height)
+    {
+        auto& buffer = owner_.create_buffer(width, height);
+        attach_visible_buffer(buffer);
     }
 
     void run_on_destruction(std::function<void()> callback)
@@ -2188,6 +2199,11 @@ wlcs::Surface::operator ::wl_surface*() const
     return impl->surface();
 }
 
+void wlcs::Surface::attach_buffer(ShmBuffer const& buffer)
+{
+    impl->attach_buffer(buffer);
+}
+
 void wlcs::Surface::attach_buffer(int width, int height)
 {
     impl->attach_buffer(width, height);
@@ -2196,6 +2212,11 @@ void wlcs::Surface::attach_buffer(int width, int height)
 void wlcs::Surface::add_frame_callback(std::function<void(int)> const& on_frame)
 {
     impl->add_frame_callback(on_frame);
+}
+
+void wlcs::Surface::attach_visible_buffer(ShmBuffer const& buffer)
+{
+    impl->attach_visible_buffer(buffer);
 }
 
 void wlcs::Surface::attach_visible_buffer(int width, int height)

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1984,6 +1984,22 @@ void wlcs::Client::add_pointer_button_notification(PointerButtonNotifier const& 
     impl->add_pointer_button_notification(on_button);
 }
 
+uint32_t wlcs::Client::move_pointer_to(Pointer& pointer, int x, int y)
+{
+    std::optional<uint32_t> enter_serial;
+    add_pointer_enter_notification(
+        [&](auto, auto, auto)
+        {
+            // Inside the enter handler the client's latest serial is, by
+            // definition, the enter serial.
+            enter_serial = latest_serial();
+            return false;
+        });
+    pointer.move_to(x, y);
+    dispatch_until([&]{ return enter_serial.has_value(); });
+    return enter_serial.value();
+}
+
 void wlcs::Client::dispatch_until(std::function<bool()> const& predicate, std::chrono::seconds timeout)
 {
     impl->dispatch_until(predicate, timeout);

--- a/tests/ext_foreign_toplevel_list_v1.cpp
+++ b/tests/ext_foreign_toplevel_list_v1.cpp
@@ -17,181 +17,18 @@
 #include "version_specifier.h"
 #include "in_process_server.h"
 #include "xdg_shell_stable.h"
-#include "generated/ext-foreign-toplevel-list-v1-client.h"
+#include "ext_foreign_toplevel_list_v1.h"
 
-#include <boost/throw_exception.hpp>
 #include <gmock/gmock.h>
 
 #include <algorithm>
 
 using namespace testing;
 
-namespace wlcs
-{
-WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_list_v1)
-WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_handle_v1)
-}
 
 namespace
 {
 int const w = 10, h = 15;
-
-class ForeignToplevelHandle
-{
-public:
-    ForeignToplevelHandle(ext_foreign_toplevel_handle_v1* handle);
-    ForeignToplevelHandle(ForeignToplevelHandle const&) = delete;
-    ForeignToplevelHandle& operator=(ForeignToplevelHandle const&) = delete;
-
-    auto is_dirty() const { return dirty_; }
-    auto closed() const { return closed_; }
-    auto title() const { return title_; }
-    auto app_id() const { return app_id_; }
-    auto identifier() const { return identifier_; }
-
-    operator ext_foreign_toplevel_handle_v1*() const { return handle; }
-
-private:
-    wlcs::WlHandle<ext_foreign_toplevel_handle_v1> const handle;
-    bool dirty_{false};
-    bool closed_{false};
-    std::optional<std::string> title_;
-    std::optional<std::string> app_id_;
-    std::optional<std::string> identifier_;
-};
-
-ForeignToplevelHandle::ForeignToplevelHandle(ext_foreign_toplevel_handle_v1* handle)
-    : handle{handle}
-{
-    static ext_foreign_toplevel_handle_v1_listener const listener = {
-        .closed = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->closed_ = true;
-                self->dirty_ = false;
-            },
-        .done = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->dirty_ = false;
-            },
-        .title = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*,
-            char const* title)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->title_ = title;
-                self->dirty_ = true;
-            },
-        .app_id = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*,
-            char const* app_id)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->app_id_ = app_id;
-                self->dirty_ = true;
-            },
-        .identifier = [](
-            void* data,
-            ext_foreign_toplevel_handle_v1*,
-            char const* identifier)
-            {
-                auto self = static_cast<ForeignToplevelHandle*>(data);
-                self->identifier_ = identifier;
-                self->dirty_ = true;
-            },
-    };
-    ext_foreign_toplevel_handle_v1_add_listener(handle, &listener, this);
-}
-
-class ForeignToplevelList
-{
-public:
-    ForeignToplevelList(wlcs::Client& client);
-
-    auto toplevels() -> std::vector<std::unique_ptr<ForeignToplevelHandle>> const&
-    {
-        return toplevels_;
-    }
-
-    auto toplevel() const -> ForeignToplevelHandle const&;
-    auto toplevel(std::string const& app_id) const -> ForeignToplevelHandle const&;
-    void remove(ForeignToplevelHandle const& toplevel);
-
-private:
-    wlcs::WlHandle<ext_foreign_toplevel_list_v1> const list;
-    std::vector<std::unique_ptr<ForeignToplevelHandle>> toplevels_;
-};
-
-ForeignToplevelList::ForeignToplevelList(wlcs::Client& client)
-    : list{client.bind_if_supported<ext_foreign_toplevel_list_v1>(wlcs::AnyVersion)}
-{
-    static ext_foreign_toplevel_list_v1_listener const listener = {
-        .toplevel = [](
-            void* data,
-            ext_foreign_toplevel_list_v1*,
-            ext_foreign_toplevel_handle_v1* toplevel)
-            {
-                auto self = static_cast<ForeignToplevelList*>(data);
-                auto handle = std::make_unique<ForeignToplevelHandle>(toplevel);
-                self->toplevels_.push_back(std::move(handle));
-            },
-        .finished = [](
-            void* /*data*/,
-            ext_foreign_toplevel_list_v1 *)
-            {
-            },
-    };
-    ext_foreign_toplevel_list_v1_add_listener(list, &listener, this);
-}
-
-auto ForeignToplevelList::toplevel() const -> ForeignToplevelHandle const&
-{
-    if (toplevels_.empty())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Manager does not know about any toplevels"));
-    if (toplevels_.size() > 1u)
-        BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Manager knows about " + std::to_string(toplevels_.size()) + " toplevels"));
-    if (toplevels_[0]->is_dirty())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
-    return *toplevels_[0];
-}
-
-auto ForeignToplevelList::toplevel(std::string const& app_id) const -> ForeignToplevelHandle const&
-{
-    std::optional<ForeignToplevelHandle const*> match;
-
-    for (auto const& i : toplevels_)
-    {
-        if (i->app_id() == app_id)
-        {
-            if (match)
-                BOOST_THROW_EXCEPTION(std::runtime_error("Multiple toplevels have the same app ID " + app_id));
-            else
-                match = i.get();
-        }
-    }
-    if (!match)
-        BOOST_THROW_EXCEPTION(std::runtime_error("No toplevels have the app ID " + app_id));
-    if (match.value()->is_dirty())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Toplevel has pending updates"));
-    return *match.value();
-}
-
-void ForeignToplevelList::remove(ForeignToplevelHandle const& toplevel)
-{
-    toplevels_.erase(std::remove_if(toplevels_.begin(), toplevels_.end(),
-        [&toplevel](auto const& item)
-            {
-                return item.get() == &toplevel;
-            }), toplevels_.end());
-}
 
 struct Window {
     Window(wlcs::Client& client)
@@ -222,7 +59,7 @@ public:
 
 TEST_F(ExtForeignToplevelListTest, does_not_detect_toplevels_when_test_creates_none)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(0u));
 }
@@ -231,7 +68,7 @@ TEST_F(ExtForeignToplevelListTest, detects_toplevel_from_same_client)
 {
     auto const surface{client.create_visible_surface(w, h)};
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(1u));
 }
@@ -242,14 +79,14 @@ TEST_F(ExtForeignToplevelListTest, detects_toplevel_from_different_client)
 
     auto const surface{client.create_visible_surface(w, h)};
 
-    ForeignToplevelList list{observer_client};
+    wlcs::ExtForeignToplevelListV1 list{observer_client};
     observer_client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(1u));
 }
 
 TEST_F(ExtForeignToplevelListTest, detects_toplevel_created_after_list)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(0u));
 
@@ -266,7 +103,7 @@ TEST_F(ExtForeignToplevelListTest, detects_multiple_toplevels_from_multiple_clie
     auto const surface{client.create_visible_surface(w, h)};
     auto const observer_surface{observer_client.create_visible_surface(w, h)};
 
-    ForeignToplevelList list{observer_client};
+    wlcs::ExtForeignToplevelListV1 list{observer_client};
     observer_client.roundtrip();
     ASSERT_THAT(list.toplevels().size(), Eq(2u));
 }
@@ -275,7 +112,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_title)
 {
     std::string const title = "Test Title @!\\-";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_title(win.xdg_toplevel, title.c_str());
     win.surface.attach_visible_buffer(w, h);
@@ -290,7 +127,7 @@ TEST_F(ExtForeignToplevelListTest, title_gets_updated)
     std::string const title_a = "Test Title @!\\-";
     std::string const title_b = "Title 2";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_title(win.xdg_toplevel, title_a.c_str());
     win.surface.attach_visible_buffer(w, h);
@@ -311,7 +148,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_app_id)
 {
     std::string const app_id = "fake.wlcs.app.id";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_app_id(win.xdg_toplevel, app_id.c_str());
     win.surface.attach_visible_buffer(w, h);
@@ -323,7 +160,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_app_id)
 
 TEST_F(ExtForeignToplevelListTest, handle_gets_identifier)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     win.surface.attach_visible_buffer(w, h);
     client.roundtrip();
@@ -334,7 +171,7 @@ TEST_F(ExtForeignToplevelListTest, handle_gets_identifier)
 
 TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_lists)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
 
     // Create and destroy a few windows to ensure we're not just
     // testing the first window gets the same identifier.
@@ -355,7 +192,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_lists)
     ASSERT_THAT((bool)list.toplevel(app_id).identifier(), Eq(true));
     auto const identifier = list.toplevel(app_id).identifier().value();
 
-    ForeignToplevelList list2{client};
+    wlcs::ExtForeignToplevelListV1 list2{client};
     client.roundtrip();
     ASSERT_THAT(list2.toplevels().size(), Eq(1u));
     EXPECT_THAT(list2.toplevels()[0]->identifier(), Eq(identifier));
@@ -363,7 +200,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_lists)
 
 TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_clients)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
 
     // Create and destroy a few windows to ensure we're not just
     // testing the first window gets the same identifier.
@@ -385,7 +222,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_clients)
     auto const identifier = list.toplevel(app_id).identifier().value();
 
     wlcs::Client client2{the_server()};
-    ForeignToplevelList list2{client2};
+    wlcs::ExtForeignToplevelListV1 list2{client2};
     client2.roundtrip();
     ASSERT_THAT(list2.toplevels().size(), Eq(1u));
     EXPECT_THAT(list2.toplevels()[0]->identifier(), Eq(identifier));
@@ -393,7 +230,7 @@ TEST_F(ExtForeignToplevelListTest, identifiers_stable_across_clients)
 
 TEST_F(ExtForeignToplevelListTest, detects_toplevel_closed)
 {
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     client.roundtrip();
     EXPECT_THAT(list.toplevels().size(), Eq(0u));
 
@@ -414,7 +251,7 @@ TEST_F(ExtForeignToplevelListTest, can_destroy_handles)
     std::string const title_a = "Title A";
     std::string const title_b = "Title B";
 
-    ForeignToplevelList list{client};
+    wlcs::ExtForeignToplevelListV1 list{client};
     Window win{client};
     xdg_toplevel_set_title(win.xdg_toplevel, title_a.c_str());
     win.surface.attach_visible_buffer(w, h);

--- a/tests/ext_image_copy_capture_v1.cpp
+++ b/tests/ext_image_copy_capture_v1.cpp
@@ -17,9 +17,11 @@
 #include "geometry/rectangle.h"
 #include "geometry/size.h"
 #include "in_process_server.h"
+#include "ext_foreign_toplevel_list_v1.h"
 #include "version_specifier.h"
 #include "wl_interface_descriptor.h"
 #include "expect_protocol_error.h"
+#include "xdg_shell_stable.h"
 #include "generated/ext-image-capture-source-v1-client.h"
 #include "generated/ext-image-copy-capture-v1-client.h"
 
@@ -28,7 +30,9 @@
 
 using namespace testing;
 
-namespace wlcs {
+namespace wlcs
+{
+WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_foreign_toplevel_image_capture_source_manager_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_output_image_capture_source_manager_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_capture_source_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_copy_capture_manager_v1)
@@ -37,7 +41,8 @@ WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_copy_capture_cursor_session_v1)
 WLCS_CREATE_INTERFACE_DESCRIPTOR(ext_image_copy_capture_frame_v1)
 } // namespace wlcs
 
-namespace {
+namespace
+{
 
 class ImageCopyCaptureFrame
 {
@@ -275,6 +280,8 @@ public:
     wlcs::Client client;
 };
 
+} // namespace
+
 TEST_F(ExtImageCopyCaptureTest, can_create_source_from_output)
 {
     auto manager = client.bind_if_supported<ext_output_image_capture_source_manager_v1>(wlcs::AnyVersion);
@@ -289,6 +296,33 @@ TEST_F(ExtImageCopyCaptureTest, can_create_session_from_output)
     auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
     auto output = client.output_state(0);
     auto source = wlcs::wrap_wl_object(ext_output_image_capture_source_manager_v1_create_source(source_manager, output.output));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    EXPECT_THAT(session.buffer_size(), Ne(std::nullopt));
+}
+
+TEST_F(ExtImageCopyCaptureTest, can_create_source_from_toplevel)
+{
+    auto manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto surface = client.create_visible_surface(100, 100);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
+    client.roundtrip();
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(manager, list.toplevel()));
+    client.roundtrip();
+}
+
+TEST_F(ExtImageCopyCaptureTest, can_create_session_from_toplevel)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    auto surface = client.create_visible_surface(100, 100);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
     ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
     client.roundtrip();
 
@@ -565,4 +599,231 @@ TEST_F(ExtImageCopyCaptureTest, cursor_session_captures_pointer_image)
     }
 }
 
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_succeeds)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = client.create_visible_surface(100, 100);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
+    // Attach our own buffer
+    wlcs::ShmBuffer surface_buffer{client, 100, 100};
+    memset(surface_buffer.data().data(), 0x7f, surface_buffer.data().size());
+    surface.attach_visible_buffer(surface_buffer);
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    wlcs::ShmBuffer shm_buffer{
+        client,
+        buffer_size.width.as_int(),
+        buffer_size.height.as_int(),
+    };
+    auto data = shm_buffer.data();
+    memset(data.data(), 0, data.size());
+
+    ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+    ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+    ext_image_copy_capture_frame_v1_capture(frame);
+    client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+
+    ASSERT_THAT(frame.is_ready(), IsTrue());
+    // At least one byte of the buffer should contain the bytes we
+    // wrote the surface's buffer. It might not exactly match the
+    // original due to being composited to an opaque buffer.
+    EXPECT_THAT(data, Contains(Eq(std::byte{0x7f})));
+
+    // First frame should damage the entire buffer
+    EXPECT_THAT(frame.damage(), ElementsAre(wlcs::Rectangle{{0, 0}, buffer_size}));
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_second_frame)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = client.create_visible_surface(100, 100);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
+    // Attach our own buffer
+    wlcs::ShmBuffer surface_buffer1{client, 100, 100};
+    memset(surface_buffer1.data().data(), 0x7f, surface_buffer1.data().size());
+    surface.attach_visible_buffer(surface_buffer1);
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    wlcs::ShmBuffer shm_buffer{
+        client,
+        buffer_size.width.as_int(),
+        buffer_size.height.as_int(),
+    };
+
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x7f})));
+    }
+
+    // Start a second frame capture, then commit a new buffer
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+
+        wlcs::ShmBuffer new_buffer{client, 100, 100};
+        memset(new_buffer.data().data(), 0x8f, new_buffer.data().size());
+        surface.attach_visible_buffer(new_buffer);
+
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x8f})));
+    }
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_continues_after_minimize)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+
+    // Create a surface we can minimize
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_surface{client, surface};
+    wlcs::XdgToplevelStable xdg_toplevel{xdg_surface};
+
+    // ack the initial xdg_surface configure
+    bool initial_configure_received = false;
+    EXPECT_CALL(xdg_surface, configure(_))
+        .WillOnce([&initial_configure_received, &xdg_surface](uint32_t serial)
+            {
+                xdg_surface_ack_configure(xdg_surface, serial);
+                initial_configure_received = true;
+            });
+    wl_surface_commit(surface);
+    client.dispatch_until([&]() { return initial_configure_received; });
+    Mock::VerifyAndClearExpectations(&xdg_surface);
+
+    // Ack any future configure events
+    EXPECT_CALL(xdg_surface, configure(_))
+        .Times(AnyNumber())
+        .WillRepeatedly(
+            [xdg_surface=static_cast<struct xdg_surface*>(xdg_surface)](uint32_t serial)
+            {
+                xdg_surface_ack_configure(xdg_surface, serial);
+            });
+
+    // Attach our own buffer
+    wlcs::ShmBuffer surface_buffer1{client, 100, 100};
+    memset(surface_buffer1.data().data(), 0x7f, surface_buffer1.data().size());
+    surface.attach_visible_buffer(surface_buffer1);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    wlcs::ShmBuffer shm_buffer{
+        client,
+        buffer_size.width.as_int(),
+        buffer_size.height.as_int(),
+    };
+
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x7f})));
+    }
+
+    // Minimize the toplevel
+    xdg_toplevel_set_minimized(xdg_toplevel);
+    client.roundtrip();
+
+    // Start a second frame capture, then commit a new buffer
+    {
+        ImageCopyCaptureFrame frame{ext_image_copy_capture_session_v1_create_frame(session)};
+        ext_image_copy_capture_frame_v1_attach_buffer(frame, shm_buffer);
+        ext_image_copy_capture_frame_v1_capture(frame);
+
+        wlcs::ShmBuffer new_buffer{client, 100, 100};
+        memset(new_buffer.data().data(), 0x8f, new_buffer.data().size());
+        surface.attach_visible_buffer(new_buffer);
+
+        client.dispatch_until([&frame]() { return frame.is_ready() || frame.failure_reason() != std::nullopt; });
+        ASSERT_THAT(frame.is_ready(), IsTrue());
+        EXPECT_THAT(shm_buffer.data(), Contains(Eq(std::byte{0x8f})));
+    }
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_handles_resize)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = client.create_visible_surface(100, 100);
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    ASSERT_THAT(session.buffer_size(), Ne(std::nullopt));
+    auto buffer_size = session.buffer_size().value();
+    // TODO: compositor could report different formats
+    ASSERT_THAT(session.shm_formats(), Contains(Eq(WL_SHM_FORMAT_ARGB8888)));
+
+    // New buffer constraints are sent after the toplevel is resized
+    surface.attach_visible_buffer(200, 200);
+    client.dispatch_until([&session, buffer_size]() { return !session.is_dirty() && session.buffer_size() != buffer_size; });
+    // This will probably be 200x200, but could potentially be
+    // scaled. So check that it is double the previous buffer size.
+    EXPECT_THAT(session.buffer_size(), Eq(wlcs::Size{buffer_size.width*2, buffer_size.height*2}));
+}
+
+TEST_F(ExtImageCopyCaptureTest, toplevel_capture_session_stops_on_surface_destroy)
+{
+    auto source_manager = client.bind_if_supported<ext_foreign_toplevel_image_capture_source_manager_v1>(wlcs::AnyVersion);
+    auto capture_manager = client.bind_if_supported<ext_image_copy_capture_manager_v1>(wlcs::AnyVersion);
+    wlcs::ExtForeignToplevelListV1 list{client};
+    auto surface = std::make_unique<wlcs::Surface>(client.create_visible_surface(100, 100));
+    client.dispatch_until([&] { return !list.toplevels().empty(); });
+
+    auto source = wlcs::wrap_wl_object(ext_foreign_toplevel_image_capture_source_manager_v1_create_source(source_manager, list.toplevel()));
+    ImageCopyCaptureSession session{ext_image_copy_capture_manager_v1_create_session(capture_manager, source, 0)};
+    client.roundtrip();
+
+    ASSERT_THAT(session.is_dirty(), IsFalse());
+    EXPECT_THAT(session.stopped(), IsFalse());
+
+    // Destroying the surface will stop the capture session
+    surface.reset();
+    client.dispatch_until([&session]() { return session.stopped(); });
 }

--- a/tests/ext_image_copy_capture_v1.cpp
+++ b/tests/ext_image_copy_capture_v1.cpp
@@ -538,15 +538,8 @@ TEST_F(ExtImageCopyCaptureTest, cursor_session_captures_pointer_image)
     // Create a surface and place the cursor over it
     wlcs::Surface surface{client.create_visible_surface(200, 200)};
     the_server().move_surface_to(surface, 0, 0);
-    std::optional<uint32_t> enter_serial;
-    client.add_pointer_enter_notification([&](auto, auto, auto)
-        {
-            enter_serial = client.latest_serial();
-            return false;
-        });
     auto pointer = the_server().create_pointer();
-    pointer.move_to(100, 100);
-    client.dispatch_until([&]() { return enter_serial.has_value(); });
+    auto const enter_serial = client.move_pointer_to(pointer, 100, 100);
 
     // Set a cursor image
     wlcs::Surface cursor_surface{client};
@@ -555,7 +548,7 @@ TEST_F(ExtImageCopyCaptureTest, cursor_session_captures_pointer_image)
     memset(data.data(), 0xff, data.size());
     wl_surface_attach(cursor_surface, cursor_buffer1, 0, 0);
     wl_surface_commit(cursor_surface);
-    wl_pointer_set_cursor(client.the_pointer(), enter_serial.value(), cursor_surface, 16, 16);
+    wl_pointer_set_cursor(client.the_pointer(), enter_serial, cursor_surface, 16, 16);
     client.roundtrip();
 
     // Create a cursor session for the output

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2024 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "in_process_server.h"
+#include "expect_protocol_error.h"
+
+#include <gmock/gmock.h>
+
+using namespace testing;
+
+namespace
+{
+class WlPointerTest : public wlcs::StartedInProcessServer
+{
+public:
+    WlPointerTest()
+        : client{the_server()},
+          pointer{the_server().create_pointer()},
+          surface{client.create_visible_surface(surface_width, surface_height)}
+    {
+        the_server().move_surface_to(surface, surface_x, surface_y);
+    }
+
+    /// Moves the pointer onto the test surface and returns the serial of the
+    /// wl_pointer.enter event this produces. Many wl_pointer requests, most
+    /// notably set_cursor, must be issued with a valid enter serial.
+    auto move_pointer_to_surface() -> uint32_t
+    {
+        std::optional<uint32_t> enter_serial;
+        client.add_pointer_enter_notification(
+            [&](auto, auto, auto)
+            {
+                // Inside the enter handler the client's latest serial is, by
+                // definition, the enter serial.
+                enter_serial = client.latest_serial();
+                return false;
+            });
+        pointer.move_to(surface_x + pointer_offset_x, surface_y + pointer_offset_y);
+        client.dispatch_until([&]{ return enter_serial.has_value(); });
+        return enter_serial.value();
+    }
+
+    /// A role-less surface suitable for use as a cursor.
+    auto make_cursor_surface() -> wlcs::Surface
+    {
+        wlcs::Surface cursor{client};
+        cursor.attach_buffer(cursor_size, cursor_size);
+        return cursor;
+    }
+
+    wlcs::Client client;
+    wlcs::Pointer pointer;
+    wlcs::Surface surface;
+
+    static int const surface_width = 200;
+    static int const surface_height = 200;
+    static int const surface_x = 100;
+    static int const surface_y = 100;
+    static int const pointer_offset_x = 50;
+    static int const pointer_offset_y = 50;
+    static int const cursor_size = 24;
+    static int const cursor_hotspot_x = 4;
+    static int const cursor_hotspot_y = 4;
+};
+}
+
+TEST_F(WlPointerTest, set_cursor_with_a_role_less_surface_is_accepted)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    auto cursor = make_cursor_surface();
+
+    EXPECT_NO_THROW({
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+        wl_surface_commit(cursor);
+        client.roundtrip();
+    });
+}
+
+TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_the_cursor)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    EXPECT_NO_THROW({
+        wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
+        client.roundtrip();
+    });
+}
+
+TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_a_previously_set_cursor)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    auto cursor = make_cursor_surface();
+
+    EXPECT_NO_THROW({
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+        wl_surface_commit(cursor);
+        client.roundtrip();
+        wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
+        client.roundtrip();
+    });
+}
+
+TEST_F(WlPointerTest, set_cursor_may_reassign_the_cursor_role_to_the_same_surface)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    auto cursor = make_cursor_surface();
+
+    // The Wayland spec explicitly allows giving a surface the cursor role
+    // again; this must not raise a protocol error.
+    EXPECT_NO_THROW({
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+        wl_surface_commit(cursor);
+        client.roundtrip();
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x + 1, cursor_hotspot_y + 1);
+        wl_surface_commit(cursor);
+        client.roundtrip();
+    });
+}
+
+TEST_F(WlPointerTest, set_cursor_on_a_surface_with_an_xdg_role_is_a_protocol_error)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    // A mapped xdg_toplevel surface already holds the toplevel role.
+    auto roled_surface = client.create_visible_surface(surface_width, surface_height);
+
+    EXPECT_PROTOCOL_ERROR({
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial, roled_surface, cursor_hotspot_x, cursor_hotspot_y);
+        client.roundtrip();
+    }, &wl_pointer_interface, WL_POINTER_ERROR_ROLE);
+}
+
+TEST_F(WlPointerTest, set_cursor_on_a_subsurface_is_a_protocol_error)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    // Creating a subsurface gives the wl_surface the subsurface role.
+    wlcs::Subsurface subsurface{surface};
+
+    EXPECT_PROTOCOL_ERROR({
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial, subsurface, cursor_hotspot_x, cursor_hotspot_y);
+        client.roundtrip();
+    }, &wl_pointer_interface, WL_POINTER_ERROR_ROLE);
+}
+
+TEST_F(WlPointerTest, set_cursor_with_a_stale_serial_is_ignored)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    // A mapped xdg_toplevel surface already holds the toplevel role, so it
+    // would be rejected if the serial were honoured. The spec requires the
+    // request to be ignored when the serial does not match the latest enter,
+    // so no protocol error must be raised.
+    auto roled_surface = client.create_visible_surface(surface_width, surface_height);
+
+    EXPECT_NO_THROW({
+        wl_pointer_set_cursor(
+            client.the_pointer(), enter_serial + 1, roled_surface, cursor_hotspot_x, cursor_hotspot_y);
+        client.roundtrip();
+    });
+}
+
+TEST_F(WlPointerTest, a_cursor_surface_cannot_be_given_a_different_role)
+{
+    auto const enter_serial = move_pointer_to_surface();
+
+    auto cursor = make_cursor_surface();
+
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+    wl_surface_commit(cursor);
+    client.roundtrip();
+
+    // The surface now has the cursor role, so trying to give it the xdg
+    // surface role must fail.
+    EXPECT_PROTOCOL_ERROR({
+        auto xdg_surface = xdg_wm_base_get_xdg_surface(client.xdg_shell_stable(), cursor);
+        client.roundtrip();
+        // (Unreachable on conformant servers, but keep the proxy tidy.)
+        xdg_surface_destroy(xdg_surface);
+    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_ROLE);
+}

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -184,6 +184,9 @@ TEST_F(WlPointerTest, set_cursor_with_a_stale_serial_is_ignored)
 
 TEST_F(WlPointerTest, a_cursor_surface_cannot_be_given_a_different_role)
 {
+    if (!client.xdg_shell_stable())
+        GTEST_SKIP() << "Compositor does not support xdg_wm_base";
+
     auto const enter_serial = move_pointer_to_surface();
 
     auto cursor = make_cursor_surface();

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -137,11 +137,12 @@ TEST_F(WlPointerTest, set_cursor_may_reassign_the_cursor_role_to_the_same_surfac
     });
 }
 
-TEST_F(WlPointerTest, set_cursor_on_a_surface_with_an_xdg_role_is_a_protocol_error)
+TEST_F(WlPointerTest, set_cursor_on_a_surface_with_another_role_is_a_protocol_error)
 {
     auto const enter_serial = move_pointer_to_surface();
 
-    // A mapped xdg_toplevel surface already holds the toplevel role.
+    // create_visible_surface gives the surface a shell role (wl_shell or
+    // xdg_toplevel, depending on what the compositor supports).
     auto roled_surface = client.create_visible_surface(surface_width, surface_height);
 
     EXPECT_PROTOCOL_ERROR({
@@ -169,10 +170,10 @@ TEST_F(WlPointerTest, set_cursor_with_a_stale_serial_is_ignored)
 {
     auto const enter_serial = move_pointer_to_surface();
 
-    // A mapped xdg_toplevel surface already holds the toplevel role, so it
-    // would be rejected if the serial were honoured. The spec requires the
-    // request to be ignored when the serial does not match the latest enter,
-    // so no protocol error must be raised.
+    // create_visible_surface gives the surface a shell role, so it would be
+    // rejected if the serial were honoured. The spec requires the request to
+    // be ignored when the serial does not match the latest enter, so no
+    // protocol error must be raised.
     auto roled_surface = client.create_visible_surface(surface_width, surface_height);
 
     EXPECT_NO_THROW({

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -21,6 +21,13 @@
 
 using namespace testing;
 
+// NOTE: WLCS currently has no way to observe the compositor's applied cursor
+// (its image, hotspot, or whether it is hidden). The "acceptance" tests below
+// can therefore only verify that a set_cursor request is not rejected with a
+// protocol error; they cannot confirm the request actually took effect. If a
+// hook to inspect the applied cursor is added in the future, these tests should
+// be extended to assert on the resulting cursor state.
+
 namespace
 {
 class WlPointerTest : public wlcs::StartedInProcessServer
@@ -83,6 +90,9 @@ TEST_F(WlPointerTest, set_cursor_with_a_role_less_surface_is_accepted)
 
     auto cursor = make_cursor_surface();
 
+    // We can only check that the request is accepted; we cannot verify the
+    // cursor image the compositor ends up showing. See the note at the top of
+    // this file.
     wl_pointer_set_cursor(
         client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
     wl_surface_commit(cursor);
@@ -93,6 +103,9 @@ TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_the_cursor)
 {
     auto const enter_serial = move_pointer_to_surface();
 
+    // A null surface asks the compositor to hide the cursor. We can only check
+    // that the request is accepted; we have no hook to confirm the cursor is
+    // actually hidden. See the note at the top of this file.
     wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
     client.roundtrip();
 }
@@ -103,6 +116,9 @@ TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_a_previously_set_cursor
 
     auto cursor = make_cursor_surface();
 
+    // As above, we can only check that hiding an already-set cursor is
+    // accepted, not that the cursor image is actually removed. See the note at
+    // the top of this file.
     wl_pointer_set_cursor(
         client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
     wl_surface_commit(cursor);
@@ -117,7 +133,9 @@ TEST_F(WlPointerTest, set_cursor_may_reassign_the_cursor_role_to_the_same_surfac
     auto cursor = make_cursor_surface();
 
     // The Wayland spec explicitly allows giving a surface the cursor role
-    // again; this must not raise a protocol error.
+    // again; this must not raise a protocol error. We can only check that the
+    // reassignment is accepted, not that the updated hotspot takes effect. See
+    // the note at the top of this file.
     wl_pointer_set_cursor(
         client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
     wl_surface_commit(cursor);
@@ -163,7 +181,9 @@ TEST_F(WlPointerTest, set_cursor_with_a_stale_serial_is_ignored)
     // create_visible_surface gives the surface a shell role, so it would be
     // rejected if the serial were honoured. The spec requires the request to
     // be ignored when the serial does not match the latest enter, so no
-    // protocol error must be raised.
+    // protocol error must be raised. We rely on the absence of a protocol
+    // error here; without a hook to inspect the applied cursor we cannot
+    // otherwise observe that the request was dropped.
     auto roled_surface = client.create_visible_surface(surface_width, surface_height);
 
     wl_pointer_set_cursor(

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -83,22 +83,18 @@ TEST_F(WlPointerTest, set_cursor_with_a_role_less_surface_is_accepted)
 
     auto cursor = make_cursor_surface();
 
-    EXPECT_NO_THROW({
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
-        wl_surface_commit(cursor);
-        client.roundtrip();
-    });
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+    wl_surface_commit(cursor);
+    client.roundtrip();
 }
 
 TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_the_cursor)
 {
     auto const enter_serial = move_pointer_to_surface();
 
-    EXPECT_NO_THROW({
-        wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
-        client.roundtrip();
-    });
+    wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
+    client.roundtrip();
 }
 
 TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_a_previously_set_cursor)
@@ -107,14 +103,11 @@ TEST_F(WlPointerTest, set_cursor_with_null_surface_hides_a_previously_set_cursor
 
     auto cursor = make_cursor_surface();
 
-    EXPECT_NO_THROW({
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
-        wl_surface_commit(cursor);
-        client.roundtrip();
-        wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
-        client.roundtrip();
-    });
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+    wl_surface_commit(cursor);
+    wl_pointer_set_cursor(client.the_pointer(), enter_serial, nullptr, 0, 0);
+    client.roundtrip();
 }
 
 TEST_F(WlPointerTest, set_cursor_may_reassign_the_cursor_role_to_the_same_surface)
@@ -125,16 +118,13 @@ TEST_F(WlPointerTest, set_cursor_may_reassign_the_cursor_role_to_the_same_surfac
 
     // The Wayland spec explicitly allows giving a surface the cursor role
     // again; this must not raise a protocol error.
-    EXPECT_NO_THROW({
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
-        wl_surface_commit(cursor);
-        client.roundtrip();
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial, cursor, cursor_hotspot_x + 1, cursor_hotspot_y + 1);
-        wl_surface_commit(cursor);
-        client.roundtrip();
-    });
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, cursor, cursor_hotspot_x, cursor_hotspot_y);
+    wl_surface_commit(cursor);
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, cursor, cursor_hotspot_x + 1, cursor_hotspot_y + 1);
+    wl_surface_commit(cursor);
+    client.roundtrip();
 }
 
 TEST_F(WlPointerTest, set_cursor_on_a_surface_with_another_role_is_a_protocol_error)
@@ -176,11 +166,9 @@ TEST_F(WlPointerTest, set_cursor_with_a_stale_serial_is_ignored)
     // protocol error must be raised.
     auto roled_surface = client.create_visible_surface(surface_width, surface_height);
 
-    EXPECT_NO_THROW({
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial + 1, roled_surface, cursor_hotspot_x, cursor_hotspot_y);
-        client.roundtrip();
-    });
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial + 1, roled_surface, cursor_hotspot_x, cursor_hotspot_y);
+    client.roundtrip();
 }
 
 TEST_F(WlPointerTest, a_cursor_surface_cannot_be_given_a_different_role)

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -46,18 +46,8 @@ public:
     /// notably set_cursor, must be issued with a valid enter serial.
     auto move_pointer_to_surface() -> uint32_t
     {
-        std::optional<uint32_t> enter_serial;
-        client.add_pointer_enter_notification(
-            [&](auto, auto, auto)
-            {
-                // Inside the enter handler the client's latest serial is, by
-                // definition, the enter serial.
-                enter_serial = client.latest_serial();
-                return false;
-            });
-        pointer.move_to(surface_x + pointer_offset_x, surface_y + pointer_offset_y);
-        client.dispatch_until([&]{ return enter_serial.has_value(); });
-        return enter_serial.value();
+        return client.move_pointer_to(
+            pointer, surface_x + pointer_offset_x, surface_y + pointer_offset_y);
     }
 
     /// A role-less surface suitable for use as a cursor.

--- a/tests/wl_pointer.cpp
+++ b/tests/wl_pointer.cpp
@@ -135,11 +135,11 @@ TEST_F(WlPointerTest, set_cursor_on_a_surface_with_another_role_is_a_protocol_er
     // xdg_toplevel, depending on what the compositor supports).
     auto roled_surface = client.create_visible_surface(surface_width, surface_height);
 
-    EXPECT_PROTOCOL_ERROR({
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial, roled_surface, cursor_hotspot_x, cursor_hotspot_y);
-        client.roundtrip();
-    }, &wl_pointer_interface, WL_POINTER_ERROR_ROLE);
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, roled_surface, cursor_hotspot_x, cursor_hotspot_y);
+    EXPECT_PROTOCOL_ERROR(
+        { client.roundtrip(); },
+        &wl_pointer_interface, WL_POINTER_ERROR_ROLE);
 }
 
 TEST_F(WlPointerTest, set_cursor_on_a_subsurface_is_a_protocol_error)
@@ -149,11 +149,11 @@ TEST_F(WlPointerTest, set_cursor_on_a_subsurface_is_a_protocol_error)
     // Creating a subsurface gives the wl_surface the subsurface role.
     wlcs::Subsurface subsurface{surface};
 
-    EXPECT_PROTOCOL_ERROR({
-        wl_pointer_set_cursor(
-            client.the_pointer(), enter_serial, subsurface, cursor_hotspot_x, cursor_hotspot_y);
-        client.roundtrip();
-    }, &wl_pointer_interface, WL_POINTER_ERROR_ROLE);
+    wl_pointer_set_cursor(
+        client.the_pointer(), enter_serial, subsurface, cursor_hotspot_x, cursor_hotspot_y);
+    EXPECT_PROTOCOL_ERROR(
+        { client.roundtrip(); },
+        &wl_pointer_interface, WL_POINTER_ERROR_ROLE);
 }
 
 TEST_F(WlPointerTest, set_cursor_with_a_stale_serial_is_ignored)
@@ -187,10 +187,8 @@ TEST_F(WlPointerTest, a_cursor_surface_cannot_be_given_a_different_role)
 
     // The surface now has the cursor role, so trying to give it the xdg
     // surface role must fail.
-    EXPECT_PROTOCOL_ERROR({
-        auto xdg_surface = xdg_wm_base_get_xdg_surface(client.xdg_shell_stable(), cursor);
-        client.roundtrip();
-        // (Unreachable on conformant servers, but keep the proxy tidy.)
-        xdg_surface_destroy(xdg_surface);
-    }, &xdg_wm_base_interface, XDG_WM_BASE_ERROR_ROLE);
+    xdg_wm_base_get_xdg_surface(client.xdg_shell_stable(), cursor);
+    EXPECT_PROTOCOL_ERROR(
+        { client.roundtrip(); },
+        &xdg_wm_base_interface, XDG_WM_BASE_ERROR_ROLE);
 }

--- a/tests/wl_surface_input_region.cpp
+++ b/tests/wl_surface_input_region.cpp
@@ -266,7 +266,57 @@ auto const multi_rect_corners = Values(
         {surface_size.first - small_rect_inset - 1, surface_size.second / 2 - 1},
         {1, 1}});
 
-// TODO: test subtract
+// A region covering the whole surface with a rectangular hole subtracted out
+// of the middle. Input should be seen on the surrounding frame but not inside
+// the hole.
+//    _______________
+//   |  ___________  |
+//   | |           | |
+//   | |   hole    | |
+//   | |___________| |
+//   |_______________|
+int const hole_inset = 30;
+
+Region const hole_region{"subtracted hole", surface_size, {
+    // whole surface...
+    {RegionAction::add, {0, 0}, surface_size},
+    // ...minus a hole in the middle
+    {RegionAction::subtract, {hole_inset, hole_inset}, {
+        surface_size.first - hole_inset * 2,
+        surface_size.second - hole_inset * 2}}}};
+
+// on_surface points sit on the frame (just outside the hole); moving by delta
+// crosses into the subtracted hole, which is outside the input region.
+auto const hole_edges = Values(
+    RegionWithTestPoints{"left edge of hole", hole_region,
+        {hole_inset - 1, surface_size.second / 2},
+        {1, 0}},
+    RegionWithTestPoints{"right edge of hole", hole_region,
+        {surface_size.first - hole_inset, surface_size.second / 2},
+        {-1, 0}},
+    RegionWithTestPoints{"top edge of hole", hole_region,
+        {surface_size.first / 2, hole_inset - 1},
+        {0, 1}},
+    RegionWithTestPoints{"bottom edge of hole", hole_region,
+        {surface_size.first / 2, surface_size.second - hole_inset},
+        {0, -1}});
+
+// Corners of the hole: on_surface sits on the frame diagonally outside the
+// hole corner, and delta moves diagonally into the hole.
+auto const hole_corners = Values(
+    RegionWithTestPoints{"top-left corner of hole", hole_region,
+        {hole_inset - 1, hole_inset - 1},
+        {1, 1}},
+    RegionWithTestPoints{"top-right corner of hole", hole_region,
+        {surface_size.first - hole_inset, hole_inset - 1},
+        {-1, 1}},
+    RegionWithTestPoints{"bottom-left corner of hole", hole_region,
+        {hole_inset - 1, surface_size.second - hole_inset},
+        {1, -1}},
+    RegionWithTestPoints{"bottom-right corner of hole", hole_region,
+        {surface_size.first - hole_inset, surface_size.second - hole_inset},
+        {-1, -1}});
+
 // TODO: test empty region
 // TODO: test default region
 
@@ -825,6 +875,16 @@ INSTANTIATE_TEST_SUITE_P(
     MultiRectCorners,
     RegionSurfaceInputCombinations,
     Combine(multi_rect_corners, xdg_stable_surface_type, all_input_types));
+
+INSTANTIATE_TEST_SUITE_P(
+    SubtractedHoleEdges,
+    RegionSurfaceInputCombinations,
+    Combine(hole_edges, xdg_stable_surface_type, all_input_types));
+
+INSTANTIATE_TEST_SUITE_P(
+    SubtractedHoleCorners,
+    RegionSurfaceInputCombinations,
+    Combine(hole_corners, xdg_stable_surface_type, all_input_types));
 
 INSTANTIATE_TEST_SUITE_P(
     SurfaceInputRegions,


### PR DESCRIPTION
Add tests/wl_pointer.cpp covering wl_pointer.set_cursor behaviour: role-less cursor surfaces, hiding the cursor with a null surface (both with and without a previously set cursor), reassigning the cursor role, the protocol errors raised when set_cursor targets a surface that already holds another role (xdg or subsurface) or when a cursor surface is later given a different role, and that a stale serial is ignored.

Note that some wl_pointer enter/leave/motion coverage already exists in tests/wl_surface_events.cpp; those tests may be moved here in the future.