### PR TITLE
wl_pointer.leave should never have a null surface and wl_pointer.enter should not assert a leave if the surface is invalid

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -372,6 +372,11 @@ public:
      */
     void flush();
 
+    /**
+     * When a surface is dropped by WLCS, 
+     */
+    void invalidate_surface(wl_surface* surface);
+
 private:
     class Impl;
     std::unique_ptr<Impl> const impl;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -372,12 +372,24 @@ public:
      */
     void flush();
 
+private:
+    friend class Surface;
+
     /**
-     * When a surface is dropped by WLCS, 
+     * Drop any input-focus bookkeeping (pointer, touch and keyboard) that
+     * refers to \p surface.
+     *
+     * When a client destroys a surface the compositor will not send a
+     * `wl_pointer.leave` (or the touch/keyboard equivalents) for it, so the
+     * stale tracking state must be cleared here. Otherwise a subsequent
+     * `wl_pointer.enter` on another surface would be misdiagnosed as a
+     * missing-leave protocol violation, and accessors such as
+     * `window_under_cursor()` would return a dangling pointer.
+     *
+     * This is called by `Surface`'s destructor.
      */
     void invalidate_surface(wl_surface* surface);
 
-private:
     class Impl;
     std::unique_ptr<Impl> const impl;
 };

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1232,6 +1232,22 @@ public:
         }
     }
 
+    void invalidate_surface(wl_surface* surface)
+    {
+        // If the surface gets destroyed, any state associated with it should
+        // be invalidated, particularly the pending_pointer_leave state, as
+        // a leave event will not be sent for a destroyed surface.
+        if (current_pointer_location.has_value())
+        {
+            if (surface == current_pointer_location.value().surface)
+            {
+                pending_pointer_leave = false;
+                pending_pointer_location.reset();
+                current_pointer_location.reset();
+            }
+        }
+    }
+
     struct Output
     {
         OutputState current;
@@ -1413,8 +1429,8 @@ private:
         if (!me->current_pointer_location)
             FAIL() << "Got wl_pointer.leave when the pointer was not on a surface";
 
-        // the surface should never be null along the wire, but may come out as null if it's been destroyed
-        if (surface != nullptr && surface != me->current_pointer_location.value().surface)
+        // The surface should never be null along the wire, as "allow-null" is not set to `true` in the protocol.
+        if (surface != me->current_pointer_location.value().surface)
             FAIL()
                 << "Got wl_pointer.leave with surface " << surface
                 << " instead of " << me->current_pointer_location.value().surface;
@@ -1999,6 +2015,11 @@ void wlcs::Client::flush()
     impl->client_flush();
 }
 
+void wlcs::Client::invalidate_surface(wl_surface* surface)
+{
+    impl->invalidate_surface(surface);
+}
+
 void* wlcs::Client::bind_if_supported(wl_interface const& interface, VersionSpecifier const& version) const
 {
     return impl->bind_if_supported(interface, version);
@@ -2021,6 +2042,8 @@ public:
 
     ~Impl()
     {
+        owner().invalidate_surface(surface());
+
         for (auto i = 0u; i < pending_callbacks.size(); )
         {
             if (pending_callbacks[i].first == this)

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1234,18 +1234,24 @@ public:
 
     void invalidate_surface(wl_surface* surface)
     {
-        // If the surface gets destroyed, any state associated with it should
-        // be invalidated, particularly the pending_pointer_leave state, as
-        // a leave event will not be sent for a destroyed surface.
-        if (current_pointer_location.has_value())
+        // If the surface gets destroyed, any input-focus state associated with
+        // it must be invalidated: the compositor will not send a
+        // wl_pointer.leave (or the touch/keyboard equivalents) for a destroyed
+        // surface, so the stale tracking state has to be dropped here.
+        if (current_pointer_location && current_pointer_location->surface == surface)
         {
-            if (surface == current_pointer_location.value().surface)
-            {
-                pending_pointer_leave = false;
-                pending_pointer_location.reset();
-                current_pointer_location.reset();
-            }
+            pending_pointer_leave = false;
+            current_pointer_location.reset();
         }
+
+        if (pending_pointer_location && pending_pointer_location->surface == surface)
+            pending_pointer_location.reset();
+
+        std::erase_if(current_touches, [surface](auto const& t) { return t.second.surface == surface; });
+        std::erase_if(pending_touches, [surface](auto const& t) { return t.second.surface == surface; });
+
+        if (keyboard_focused_surface == surface)
+            keyboard_focused_surface = nullptr;
     }
 
     struct Output
@@ -2042,8 +2048,6 @@ public:
 
     ~Impl()
     {
-        owner().invalidate_surface(surface());
-
         for (auto i = 0u; i < pending_callbacks.size(); )
         {
             if (pending_callbacks[i].first == this)
@@ -2213,7 +2217,12 @@ wlcs::Surface::Surface(Client& client)
 {
 }
 
-wlcs::Surface::~Surface() = default;
+wlcs::Surface::~Surface()
+{
+    // A moved-from Surface has a null impl and owns nothing to invalidate.
+    if (impl)
+        owner().invalidate_surface(*this);
+}
 
 wlcs::Surface::Surface(Surface&&) = default;
 


### PR DESCRIPTION
## Problem
Our WLCS test suite assumed that a `wl_pointer.leave` event could fire with a null surface, but this is incorrect. Null must be explicitly allowed per the Wayland protocol, so any event sending null here would be an error.

## Solution
- Disallow null surfaces in wl_pointer.leave. This should be a `FAIL` going forward
- When a surface is destroyed, we invalidate any state that it was associated with, as future events cannot reliably compare against a window that has been destroyed

pairs with https://github.com/canonical/mir/pull/5180